### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/sitemap": "3.4.0",
         "@astrojs/svelte": "7.1.0",
         "astro": "5.8.0",
-        "svelte": "5.33.1",
+        "svelte": "5.33.4",
         "tailwindcss": "4.1.7",
         "typescript": "5.8.3"
       },
@@ -6689,9 +6689,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.33.1.tgz",
-      "integrity": "sha512-7znzaaQALL62NBzkdKV04tmYIVla8qjrW+k6GdgFZcKcj8XOb8iEjmfRPo40iaWZlKv3+uiuc0h4iaGgwoORtA==",
+      "version": "5.33.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.33.4.tgz",
+      "integrity": "sha512-w2+ksGaZRgZgQdP2dtOjlpkdQwX3ftc8+BH/W9XgX6rP1FZHCeuXQnmyeHPFLbG2Gjj9pp2ak8iIeVure+n7IA==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@astrojs/sitemap": "3.4.0",
     "@astrojs/svelte": "7.1.0",
     "astro": "5.8.0",
-    "svelte": "5.33.1",
+    "svelte": "5.33.4",
     "tailwindcss": "4.1.7",
     "typescript": "5.8.3"
   },


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ svelte  5.33.1  →  5.33.4