### PR TITLE
content(slides): mobile landscape 2026 — companion deck for the learning-mobile series

### DIFF
--- a/src/content/slides/en/2026-04-26_mobile-landscape-2026.md
+++ b/src/content/slides/en/2026-04-26_mobile-landscape-2026.md
@@ -1,0 +1,333 @@
+---
+type: internal
+title: "The Mobile Landscape in 2026"
+description: "The map I made before writing code: nine mobile frameworks, four categories, and why Flutter and KMP became the only two paths I'm still considering."
+pubDate: 2026-04-26
+tags: [tech, mobile, talks]
+draft: true
+theme: dark
+transition: slide
+syntaxHighlight: true
+math: false
+eventName: "Learning Mobile Development — Series Companion Deck"
+eventDate: 2026-04-26
+relatedPost: mobile-development-landscape-2026
+---
+
+<!-- ==================== Cover ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #0f172a 0%, #1e3a5f 60%, #2a76dd 100%)" -->
+
+# Mobile in 2026
+
+### The map I made before writing code
+
+<small>Sergio Alexander Florez · April 2026</small>
+
+Note: Open with the personal angle — this isn't a comparison report; it's a map I drew for myself before learning mobile from scratch as a backend developer.
+
+---
+
+<!-- ==================== Section 01 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Part 01</span>
+  <h2>Why I kept avoiding it</h2>
+</div>
+
+---
+
+<div class="slide-stat">
+  <span class="slide-stat__number">15+</span>
+  <span class="slide-stat__label">years calling myself "full stack" while skipping mobile entirely</span>
+  <p class="slide-stat__context">Backend, frontend, infra, DevOps — but mobile? Always "the thing other people do."</p>
+</div>
+
+---
+
+## Where it started
+
+<div class="slide-grid-2 slide-grid--align-center">
+  <div>
+    <img src="/images/blog/posts/mobile-development-landscape-2026/eclipse-helios-loading.webp" alt="Eclipse Helios IDE loading screen with the ADT plugin, circa 2011" width="1024" height="576" class="slide-image-full" />
+  </div>
+  <div>
+    <h3>~2011 · University course</h3>
+    <p>Eclipse Helios + ADT plugin. The IDE that ate every byte of RAM my laptop had. Before "Hello World" you'd been through three setup wizards.</p>
+  </div>
+</div>
+
+---
+
+<blockquote class="slide-quote">
+  "Logistics kills motivation faster than complexity."
+</blockquote>
+<cite class="slide-quote-cite">— Sergio Florez · Mobile Landscape 2026</cite>
+
+---
+
+## Backend instinct vs mobile reality
+
+<div class="slide-grid-2">
+  <div>
+    <h3>What I knew</h3>
+    <ul>
+      <li>State lives on the server</li>
+      <li>Request → response → snapshot</li>
+      <li>Three lines spin up a server</li>
+    </ul>
+  </div>
+  <div>
+    <h3>What mobile actually is</h3>
+    <ul>
+      <li>State lives in the screen</li>
+      <li>OS can destroy and recreate it</li>
+      <li>Lifecycle ramifies through every decision</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Section 02 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Part 02</span>
+  <h2>Four categories before the list</h2>
+</div>
+
+---
+
+## The four categories
+
+<div class="slide-grid-3">
+  <div class="slide-card">
+    <span class="slide-card__icon">🔒</span>
+    <h3>Native</h3>
+    <p>One platform, one language, full OS access. Maximum control, maximum lock-in.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">🔀</span>
+    <h3>Cross-platform</h3>
+    <p>Shared logic or UI compiled to native. KMP and Flutter live here — different philosophies.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">🌐</span>
+    <h3>Hybrid / Web</h3>
+    <p>Web tech inside a native shell, or a PWA you install. Lowest friction, real ceilings.</p>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Section 03 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Part 03</span>
+  <h2>Nine options on the map</h2>
+</div>
+
+---
+
+## Side by side
+
+<table class="slide-table">
+  <thead>
+    <tr><th>Option</th><th>Language</th><th>Platforms</th><th>UI</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Native Android</td><td>Kotlin + Compose</td><td>Android</td><td>Native</td></tr>
+    <tr><td>Native iOS</td><td>Swift + SwiftUI</td><td>Apple</td><td>Native</td></tr>
+    <tr><td>Kotlin Multiplatform</td><td>Kotlin</td><td>Android, iOS, Desktop, Web</td><td>Native (or Compose MP)</td></tr>
+    <tr><td>Flutter</td><td>Dart</td><td>Android, iOS, Web, Desktop</td><td>Custom (Impeller)</td></tr>
+    <tr><td>React Native</td><td>JS / TS</td><td>Android, iOS</td><td>Native via JSI</td></tr>
+    <tr><td>.NET MAUI</td><td>C#</td><td>Android, iOS, Win, macOS</td><td>Native via .NET</td></tr>
+    <tr><td>Ionic + Capacitor</td><td>HTML / CSS / JS</td><td>Android, iOS, Web</td><td>WebView</td></tr>
+    <tr><td>PWA</td><td>HTML / CSS / JS</td><td>Any browser</td><td>Web</td></tr>
+    <tr><td><s>Xamarin</s></td><td><s>C#</s></td><td>—</td><td>EOL May 2024</td></tr>
+  </tbody>
+</table>
+
+---
+
+<!-- .slide: class="slide-bg-pattern--grid" -->
+
+## Quick rule-outs
+
+<div class="slide-grid-2">
+  <div>
+    <h3>Out</h3>
+    <ul>
+      <li><strong>Native only</strong> — I want to reach both</li>
+      <li><strong>Ionic / Capacitor</strong> — lived this, hit the ceiling</li>
+      <li><strong>.NET MAUI</strong> — not in the C# world</li>
+      <li><strong>PWA</strong> — need real device access</li>
+      <li><strong>Xamarin</strong> — EOL</li>
+    </ul>
+  </div>
+  <div>
+    <h3>Maybe</h3>
+    <ul>
+      <li><strong>React Native</strong> — solid, but JS-rooted</li>
+    </ul>
+    <h3>Stays</h3>
+    <ul>
+      <li><strong>Flutter</strong> — fastest path to a first result</li>
+      <li><strong>Kotlin Multiplatform</strong> — the more defensible long-term bet</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Section 04 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #2a76dd 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Part 04</span>
+  <h2>Two paths, two philosophies</h2>
+</div>
+
+---
+
+## Two bets about "cross-platform"
+
+<div class="slide-grid-2">
+  <div>
+    <h3>🐦 Flutter</h3>
+    <p><em>"Trust our renderer, write once."</em></p>
+    <ul>
+      <li>Dart + Impeller engine</li>
+      <li>Same UI on every platform — by design</li>
+      <li>Hot reload, mature pub.dev</li>
+      <li><strong>3.41</strong> · Feb 2026</li>
+    </ul>
+  </div>
+  <div>
+    <h3>🟣 Kotlin Multiplatform</h3>
+    <p><em>"Share the logic, keep the UI native."</em></p>
+    <ul>
+      <li>Kotlin shared layer · native UI per platform</li>
+      <li>Jetpack Compose ↔ SwiftUI on each side</li>
+      <li>Stable since Nov 2023</li>
+      <li>Compose MP <strong>1.10</strong> · Jan 2026</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<div class="slide-stat">
+  <span class="slide-stat__number">7% → 18%</span>
+  <span class="slide-stat__label">KMP adoption growth among developers in a single year</span>
+  <p class="slide-stat__context">Source: JetBrains Developer Ecosystem Survey</p>
+</div>
+
+---
+
+## KMP — the long road to here
+
+<ul class="slide-timeline">
+  <li><time>2017</time><span>Introduced in Kotlin 1.2 at KotlinConf</span></li>
+  <li><time>Nov 2023</time><span>KMP declared stable</span></li>
+  <li><time>May 2025</time><span>Compose Multiplatform for iOS goes stable</span></li>
+  <li><time>Jan 2026</time><span>Compose MP 1.10.0 released</span></li>
+  <li><time>2026</time><span>Google migrating Jetpack libs (Room, DataStore, ViewModel) to KMP</span></li>
+</ul>
+
+---
+
+## What each one costs you
+
+<div class="slide-grid-2">
+  <div>
+    <h3>Flutter — honest tradeoffs</h3>
+    <ul>
+      <li>Dart only exists for Flutter</li>
+      <li>UI doesn't fully belong to either platform</li>
+      <li>Custom renderer ≠ true native feel</li>
+    </ul>
+  </div>
+  <div>
+    <h3>KMP — honest tradeoffs</h3>
+    <ul>
+      <li>Steeper learning curve</li>
+      <li>Two UI layers to maintain</li>
+      <li>Xcode integration still rough at the edges</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Section 05 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Part 05</span>
+  <h2>The plan from here</h2>
+</div>
+
+---
+
+## Process — what comes next
+
+<ol class="slide-steps">
+  <li><strong>Map</strong><br/>Understand the landscape (this chapter).</li>
+  <li><strong>KMP first</strong><br/>Where curiosity landed. Build something real.</li>
+  <li><strong>Then Flutter</strong><br/>Same exercise. Same yardstick.</li>
+  <li><strong>Choose</strong><br/>After both, with evidence — not vibes.</li>
+</ol>
+
+---
+
+<blockquote class="slide-quote">
+  "A map isn't the territory. The territory is what I came to learn."
+</blockquote>
+<cite class="slide-quote-cite">— Sergio Florez · Closing the chapter</cite>
+
+---
+
+## What this series WON'T be
+
+<div class="slide-grid-3">
+  <div class="slide-card">
+    <span class="slide-card__icon">❌</span>
+    <h3>An expert take</h3>
+    <p>I'm starting from zero. The arrogance of arrival hasn't caught up yet.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">❌</span>
+    <h3>A "Flutter vs KMP" doc</h3>
+    <p>Comparison documents pretend the answer is universal. It isn't.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">✅</span>
+    <h3>A real journey</h3>
+    <p>Built in public, with tradeoffs named, decisions logged, mistakes published.</p>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Closing ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #0f172a 0%, #2a76dd 100%)" -->
+
+## Read the series
+
+<p>The full chapter (and the next ones) live on the blog:</p>
+
+<a href="/blog/series/learning-mobile-development" class="slide-cta">Open the series →</a>
+
+<small>xergioalex.com · @XergioAleX</small>
+
+Note: Closing — invite the audience to follow along. The series builds in public; chapter 2 dives into KMP from zero.

--- a/src/content/slides/es/2026-04-26_mobile-landscape-2026.md
+++ b/src/content/slides/es/2026-04-26_mobile-landscape-2026.md
@@ -1,0 +1,333 @@
+---
+type: internal
+title: "El panorama móvil en 2026"
+description: "El mapa que armé antes de escribir código: nueve frameworks, cuatro categorías, y por qué Flutter y KMP quedaron como los dos caminos serios."
+pubDate: 2026-04-26
+tags: [tech, mobile, talks]
+draft: true
+theme: dark
+transition: slide
+syntaxHighlight: true
+math: false
+eventName: "Aprendiendo desarrollo móvil — Deck companion de la serie"
+eventDate: 2026-04-26
+relatedPost: mobile-development-landscape-2026
+---
+
+<!-- ==================== Portada ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #0f172a 0%, #1e3a5f 60%, #2a76dd 100%)" -->
+
+# Móvil en 2026
+
+### El mapa que armé antes de escribir código
+
+<small>Sergio Alexander Florez · Abril 2026</small>
+
+Note: Abrir con el ángulo personal — esto no es un reporte comparativo; es un mapa que dibujé para mí antes de aprender móvil desde cero como desarrollador backend.
+
+---
+
+<!-- ==================== Sección 01 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Parte 01</span>
+  <h2>Por qué lo seguía evitando</h2>
+</div>
+
+---
+
+<div class="slide-stat">
+  <span class="slide-stat__number">15+</span>
+  <span class="slide-stat__label">años llamándome "full stack" mientras esquivaba móvil por completo</span>
+  <p class="slide-stat__context">Backend, frontend, infra, DevOps — pero móvil siempre fue "lo que hacen los demás".</p>
+</div>
+
+---
+
+## Dónde empezó
+
+<div class="slide-grid-2 slide-grid--align-center">
+  <div>
+    <img src="/images/blog/posts/mobile-development-landscape-2026/eclipse-helios-loading.webp" alt="Pantalla de carga de Eclipse Helios con el plugin ADT, alrededor de 2011" width="1024" height="576" class="slide-image-full" />
+  </div>
+  <div>
+    <h3>~2011 · Curso universitario</h3>
+    <p>Eclipse Helios + plugin ADT. El IDE que se comía cada byte de RAM de mi laptop. Antes del "Hello World" ya habías pasado por tres asistentes de configuración.</p>
+  </div>
+</div>
+
+---
+
+<blockquote class="slide-quote">
+  "La logística mata la motivación más rápido que la complejidad."
+</blockquote>
+<cite class="slide-quote-cite">— Sergio Florez · Panorama móvil 2026</cite>
+
+---
+
+## Instinto de backend vs realidad móvil
+
+<div class="slide-grid-2">
+  <div>
+    <h3>Lo que sabía</h3>
+    <ul>
+      <li>El estado vive en el servidor</li>
+      <li>Request → response → snapshot</li>
+      <li>Tres líneas levantan un servidor</li>
+    </ul>
+  </div>
+  <div>
+    <h3>Lo que móvil realmente es</h3>
+    <ul>
+      <li>El estado vive en la pantalla</li>
+      <li>El SO puede destruirla y recrearla</li>
+      <li>El ciclo de vida ramifica cada decisión</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Sección 02 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Parte 02</span>
+  <h2>Cuatro categorías antes de la lista</h2>
+</div>
+
+---
+
+## Las cuatro categorías
+
+<div class="slide-grid-3">
+  <div class="slide-card">
+    <span class="slide-card__icon">🔒</span>
+    <h3>Native</h3>
+    <p>Una plataforma, un lenguaje, acceso total al SO. Máximo control, máximo lock-in.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">🔀</span>
+    <h3>Cross-platform</h3>
+    <p>Lógica o UI compartida que compila a nativo. KMP y Flutter viven aquí — filosofías distintas.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">🌐</span>
+    <h3>Hybrid / Web</h3>
+    <p>Tecnología web dentro de un shell nativo, o una PWA que instalas. Mínima fricción, techos reales.</p>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Sección 03 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Parte 03</span>
+  <h2>Nueve opciones en el mapa</h2>
+</div>
+
+---
+
+## Lado a lado
+
+<table class="slide-table">
+  <thead>
+    <tr><th>Opción</th><th>Lenguaje</th><th>Plataformas</th><th>UI</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Android nativo</td><td>Kotlin + Compose</td><td>Android</td><td>Nativa</td></tr>
+    <tr><td>iOS nativo</td><td>Swift + SwiftUI</td><td>Apple</td><td>Nativa</td></tr>
+    <tr><td>Kotlin Multiplatform</td><td>Kotlin</td><td>Android, iOS, Desktop, Web</td><td>Nativa (o Compose MP)</td></tr>
+    <tr><td>Flutter</td><td>Dart</td><td>Android, iOS, Web, Desktop</td><td>Custom (Impeller)</td></tr>
+    <tr><td>React Native</td><td>JS / TS</td><td>Android, iOS</td><td>Nativa vía JSI</td></tr>
+    <tr><td>.NET MAUI</td><td>C#</td><td>Android, iOS, Win, macOS</td><td>Nativa vía .NET</td></tr>
+    <tr><td>Ionic + Capacitor</td><td>HTML / CSS / JS</td><td>Android, iOS, Web</td><td>WebView</td></tr>
+    <tr><td>PWA</td><td>HTML / CSS / JS</td><td>Cualquier navegador</td><td>Web</td></tr>
+    <tr><td><s>Xamarin</s></td><td><s>C#</s></td><td>—</td><td>EOL Mayo 2024</td></tr>
+  </tbody>
+</table>
+
+---
+
+<!-- .slide: class="slide-bg-pattern--grid" -->
+
+## Descartes rápidos
+
+<div class="slide-grid-2">
+  <div>
+    <h3>Fuera</h3>
+    <ul>
+      <li><strong>Solo nativo</strong> — quiero llegar a ambas</li>
+      <li><strong>Ionic / Capacitor</strong> — viví esto, choqué el techo</li>
+      <li><strong>.NET MAUI</strong> — no estoy en el mundo C#</li>
+      <li><strong>PWA</strong> — necesito acceso real al dispositivo</li>
+      <li><strong>Xamarin</strong> — EOL</li>
+    </ul>
+  </div>
+  <div>
+    <h3>Quizás</h3>
+    <ul>
+      <li><strong>React Native</strong> — sólido, pero raíces JS</li>
+    </ul>
+    <h3>Quedan</h3>
+    <ul>
+      <li><strong>Flutter</strong> — el camino más rápido a un primer resultado</li>
+      <li><strong>Kotlin Multiplatform</strong> — la apuesta más defendible a largo plazo</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Sección 04 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #2a76dd 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Parte 04</span>
+  <h2>Dos caminos, dos filosofías</h2>
+</div>
+
+---
+
+## Dos apuestas sobre "cross-platform"
+
+<div class="slide-grid-2">
+  <div>
+    <h3>🐦 Flutter</h3>
+    <p><em>"Confía en nuestro renderer, escribe una vez."</em></p>
+    <ul>
+      <li>Dart + motor Impeller</li>
+      <li>Misma UI en todas las plataformas — por diseño</li>
+      <li>Hot reload, pub.dev maduro</li>
+      <li><strong>3.41</strong> · Feb 2026</li>
+    </ul>
+  </div>
+  <div>
+    <h3>🟣 Kotlin Multiplatform</h3>
+    <p><em>"Comparte la lógica, mantén la UI nativa."</em></p>
+    <ul>
+      <li>Capa Kotlin compartida · UI nativa por plataforma</li>
+      <li>Jetpack Compose ↔ SwiftUI a cada lado</li>
+      <li>Estable desde Nov 2023</li>
+      <li>Compose MP <strong>1.10</strong> · Ene 2026</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<div class="slide-stat">
+  <span class="slide-stat__number">7% → 18%</span>
+  <span class="slide-stat__label">Crecimiento de adopción de KMP entre desarrolladores en un año</span>
+  <p class="slide-stat__context">Fuente: JetBrains Developer Ecosystem Survey</p>
+</div>
+
+---
+
+## KMP — el largo camino hasta acá
+
+<ul class="slide-timeline">
+  <li><time>2017</time><span>Introducido en Kotlin 1.2 en KotlinConf</span></li>
+  <li><time>Nov 2023</time><span>KMP declarado estable</span></li>
+  <li><time>May 2025</time><span>Compose Multiplatform para iOS pasa a estable</span></li>
+  <li><time>Ene 2026</time><span>Compose MP 1.10.0 liberado</span></li>
+  <li><time>2026</time><span>Google migrando librerías Jetpack (Room, DataStore, ViewModel) a KMP</span></li>
+</ul>
+
+---
+
+## Lo que cuesta cada uno
+
+<div class="slide-grid-2">
+  <div>
+    <h3>Flutter — tradeoffs honestos</h3>
+    <ul>
+      <li>Dart solo existe para Flutter</li>
+      <li>La UI no termina de pertenecer a ninguna plataforma</li>
+      <li>Renderer custom ≠ sensación nativa real</li>
+    </ul>
+  </div>
+  <div>
+    <h3>KMP — tradeoffs honestos</h3>
+    <ul>
+      <li>Curva de aprendizaje más empinada</li>
+      <li>Dos capas de UI que mantener</li>
+      <li>Integración con Xcode todavía áspera en los bordes</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Sección 05 ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)" -->
+
+<div class="slide-section-divider">
+  <span class="eyebrow">Parte 05</span>
+  <h2>El plan desde acá</h2>
+</div>
+
+---
+
+## Proceso — qué viene
+
+<ol class="slide-steps">
+  <li><strong>Mapa</strong><br/>Entender el panorama (este capítulo).</li>
+  <li><strong>KMP primero</strong><br/>Donde aterrizó la curiosidad. Construir algo real.</li>
+  <li><strong>Después Flutter</strong><br/>El mismo ejercicio. La misma vara.</li>
+  <li><strong>Decidir</strong><br/>Después de ambos, con evidencia — no con vibras.</li>
+</ol>
+
+---
+
+<blockquote class="slide-quote">
+  "Un mapa no es el territorio. El territorio es a lo que vine a aprender."
+</blockquote>
+<cite class="slide-quote-cite">— Sergio Florez · Cierre del capítulo</cite>
+
+---
+
+## Lo que esta serie NO va a ser
+
+<div class="slide-grid-3">
+  <div class="slide-card">
+    <span class="slide-card__icon">❌</span>
+    <h3>Una mirada de experto</h3>
+    <p>Estoy arrancando desde cero. La arrogancia de la llegada todavía no apareció.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">❌</span>
+    <h3>Un doc "Flutter vs KMP"</h3>
+    <p>Los documentos comparativos fingen que la respuesta es universal. No lo es.</p>
+  </div>
+  <div class="slide-card">
+    <span class="slide-card__icon">✅</span>
+    <h3>Un viaje real</h3>
+    <p>Construido en público, con tradeoffs nombrados, decisiones registradas, errores publicados.</p>
+  </div>
+</div>
+
+---
+
+<!-- ==================== Cierre ==================== -->
+
+<!-- .slide: data-background-gradient="linear-gradient(135deg, #0f172a 0%, #2a76dd 100%)" -->
+
+## Lee la serie
+
+<p>El capítulo completo (y los siguientes) viven en el blog:</p>
+
+<a href="/es/blog/series/learning-mobile-development" class="slide-cta">Abrir la serie →</a>
+
+<small>xergioalex.com · @XergioAleX</small>
+
+Note: Cierre — invitar a la audiencia a seguir la serie. Se construye en público; el capítulo 2 entra a KMP desde cero.


### PR DESCRIPTION
## Summary

Companion slide deck for the **Learning Mobile Development** blog series (chapter 1 — *The Mobile Landscape in 2026*). Built as a real-world stress-test of the v2 layout primitives shipped in PR #111.

22 slides in EN + ES, `draft: true` (visible in dev / preview only).

## What's inside

5 narrative parts × every v2 primitive:

- **Part 01 — Why I kept avoiding it:** big-stat (15+ years), image-left (Eclipse Helios screenshot from the blog post), pull-quote, two-column split (backend instinct vs mobile reality).
- **Part 02 — Four categories before the list:** three-column cards.
- **Part 03 — Nine options on the map:** comparison table (all 9 frameworks), grid-pattern background slide with two-column rule-outs.
- **Part 04 — Two paths, two philosophies:** Flutter vs KMP split, big-stat (7%→18% adoption from JetBrains DevEcosystem), KMP timeline (2017→2026), tradeoff split.
- **Part 05 — The plan from here:** process-steps (Map → KMP → Flutter → Choose), pull-quote, three-column "what this series WON'T be," closing CTA to `/blog/series/learning-mobile-development`.

Backgrounds used: 4 different gradients + 1 grid pattern + dark default.

## Sources & accuracy

All facts sourced from the published chapter 1 blog post — KMP stable Nov 2023, Compose MP 1.10 Jan 2026, Flutter 3.41 Feb 2026, Xamarin EOL May 2024, JetBrains adoption stat. No invented data.

## SEO / AEO

- Description 149 chars (EN) / 145 chars (ES) — within the 130-160 window.
- Tags `[tech, mobile, talks]` derive `<meta name="keywords">` and JSON-LD `keywords`.
- `relatedPost: mobile-development-landscape-2026` links the deck's Markdown twin to the chapter 1 blog post.
- `eventName` + `eventDate` populate JSON-LD `about: Event`.
- `draft: true` keeps it out of production until published deliberately (recommended: alongside the blog series launch).

## Validation

- ✅ `npm run biome:check`
- ✅ `npm run astro:check` — 0/0/0
- ✅ `npm run build` — 283 pages (no extra; deck is draft)
- ✅ Spanish diacritics clean

## Test plan

- [ ] `npm run dev` → open `/slides/mobile-landscape-2026` in dark mode; walk all 22 slides
- [ ] Same in light mode
- [ ] Repeat at 375 / 768 / 1440px via DevTools
- [ ] Same on `/es/slides/mobile-landscape-2026`
- [ ] Eclipse Helios image renders in image-left layout
- [ ] Comparison table readable on mobile (font shrinks below 640px)
- [ ] Grid-pattern background slide ("descartes rápidos") shows the pattern
- [ ] Closing CTA links resolve

## Notes

- Branch already merged origin/main (v1.0.12 release) into dev — clean fast-forward of `package.json` + `package-lock.json` only.
- Deck stays `draft: true` until you flip it; Cloudflare Pages preview branches will render it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)