### PR TITLE
content(slides): publish mobile-landscape-2026 deck

### DIFF
--- a/src/content/slides/en/2026-04-26_mobile-landscape-2026.md
+++ b/src/content/slides/en/2026-04-26_mobile-landscape-2026.md
@@ -2,9 +2,9 @@
 type: internal
 title: "The Mobile Landscape in 2026"
 description: "The map I made before writing code: nine mobile frameworks, four categories, and why Flutter and KMP became the only two paths I'm still considering."
-pubDate: 2026-04-26
+pubDate: 2026-04-25
 tags: [tech, mobile, talks]
-draft: true
+draft: false
 theme: dark
 transition: slide
 syntaxHighlight: true

--- a/src/content/slides/es/2026-04-26_mobile-landscape-2026.md
+++ b/src/content/slides/es/2026-04-26_mobile-landscape-2026.md
@@ -2,9 +2,9 @@
 type: internal
 title: "El panorama móvil en 2026"
 description: "El mapa que armé antes de escribir código: nueve frameworks, cuatro categorías, y por qué Flutter y KMP quedaron como los dos caminos serios."
-pubDate: 2026-04-26
+pubDate: 2026-04-25
 tags: [tech, mobile, talks]
-draft: true
+draft: false
 theme: dark
 transition: slide
 syntaxHighlight: true


### PR DESCRIPTION
## Summary

Publishes the **mobile landscape 2026** companion deck (EN + ES) to production.

## Changes

- `draft: true` → `false` on both `src/content/slides/{en,es}/2026-04-26_mobile-landscape-2026.md`.
- `pubDate: 2026-04-26` → `2026-04-25` on both — see "Date adjustment" below.

## Date adjustment

`isScheduledDeck()` (`src/lib/slides.ts`) compares each deck's `pubDate` to "today in `America/Bogota`" (the site timezone). At commit time it was 22:46 of 2026-04-25 in Bogota while UTC had already rolled into 2026-04-26. With `pubDate: 2026-04-26`, the deck was treated as **scheduled for the future** and excluded from production builds (verified locally — deck files were missing from `dist/slides/`).

Backing the pubDate down by one day lands it inside the visible window. The filename keeps the `2026-04-26_` prefix, but the URL slug is derived from the part after the date prefix (`mobile-landscape-2026`), so URLs are unchanged:

- `/slides/mobile-landscape-2026/` (and `.md` twin)
- `/es/slides/mobile-landscape-2026/` (and `.md` twin)

## Validation

- ✅ `npm run astro:check` — 0/0/0
- ✅ `npm run build` — **285 pages** (was 283; +2 HTML + 2 Markdown twins for the EN + ES deck pages)
- ✅ Sitemap includes both deck URLs

## Test plan

Once merged and deployed:

- [ ] `https://xergioalex.com/slides/` lists the mobile landscape deck card
- [ ] `https://xergioalex.com/slides/mobile-landscape-2026` renders all 22 slides
- [ ] `https://xergioalex.com/es/slides/mobile-landscape-2026` renders ES version
- [ ] AEO twins respond at `/slides/mobile-landscape-2026.md` and `/es/slides/mobile-landscape-2026.md`
- [ ] Dark + light mode look clean across the deck
- [ ] Eclipse Helios image (image-left slide) loads from `/images/blog/posts/mobile-development-landscape-2026/eclipse-helios-loading.webp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)