### PR TITLE
feat(blog): link kdosensei repo and refine mobile landscape post copy

### DIFF
--- a/src/content/blog/en/2026-04-26_mobile-development-landscape-2026.md
+++ b/src/content/blog/en/2026-04-26_mobile-development-landscape-2026.md
@@ -85,7 +85,7 @@ For the university course, our team was Camilo, Miguel, and me. Camilo and Migue
 <figcaption>Three kihon detail screens using the outdoor shoot photos and short movement notes.</figcaption>
 </figure>
 
-Years later I dug up my course files — source included — along with the original Android APKs. Those packages don't run cleanly on today's devices anymore — newer OS releases have mostly left them behind — but the web layer was worth saving. Hybrid apps like that are still, at heart, embedded web inside a native shell. I put that same frontend online as a static site on [Cloudflare Pages](https://pages.cloudflare.com/) at [kdosensei.xergioalex.com](https://kdosensei.xergioalex.com/).
+Years later I dug up my course files — source included — along with the original Android APKs. Those packages don't run cleanly on today's devices anymore — newer OS releases have mostly left them behind — but the web layer was worth saving. Hybrid apps like that are still, at heart, embedded web inside a native shell. I put that same frontend online as a static site on [Cloudflare Pages](https://pages.cloudflare.com/) at [kdosensei.xergioalex.com](https://kdosensei.xergioalex.com/), and collected the recovered files in the [xergioalex/kdosensei](https://github.com/xergioalex/kdosensei) repo — a time-machine snapshot of that semester, the team, and the hybrid tooling, kept intact instead of vanishing in some forgotten zip on an old drive.
 
 I didn't close the book there. Over the years I tried [Ionic](https://ionicframework.com/) — same idea, better tooling, faster prototypes — **Meteor** bundled with Cordova (reactive and tempting until production felt fragile), and some experiments with **React Native**, closer to native but with its own friction. Each round taught me the ceiling of the last one.
 
@@ -111,9 +111,7 @@ A web app runs inside the browser, a relatively predictable environment: an open
 
 It's not that web doesn't have complexity — it does, whether backend or frontend. It's that the complexity is different: the instinct you've built up handling requests or component reactivity doesn't transfer directly to this domain, because the runtime isn't yours anymore — it's the operating system's.
 
-It's a pattern I'm going to find over and over in this series: the instincts you build up in web development are valid, but they don't transfer directly. Part of learning mobile is figuring out when to trust what you already know and when to set it aside.
-
-That said: the framework does matter. And there are too many to choose from without understanding the terrain first.
+That said: the framework does matter, and it's worth understanding the terrain before choosing.
 
 ## Four categories before the list
 

--- a/src/content/blog/es/2026-04-26_mobile-development-landscape-2026.md
+++ b/src/content/blog/es/2026-04-26_mobile-development-landscape-2026.md
@@ -85,7 +85,7 @@ En el proyecto de la universidad mi grupo lo conformábamos Camilo, Miguel y yo:
 <figcaption>Detalle de tres kihon con las fotos de la sesión al aire libre y la descripción del movimiento.</figcaption>
 </figure>
 
-Años después desempolvé mis archivos de la universidad, encontré el código fuente e incluso los APK originales de Android. Esos binarios ya no funcionan en equipos de ahora — las versiones nuevas del sistema los fueron dejando atrás —, pero pude rescatar la capa web: en el fondo, una app híbrida así es una web embebida dentro del contenedor móvil. Ese mismo frontend lo desplegué como sitio estático en [Cloudflare Pages](https://pages.cloudflare.com/) en [kdosensei.xergioalex.com](https://kdosensei.xergioalex.com/).
+Años después desempolvé mis archivos de la universidad, encontré el código fuente e incluso los APK originales de Android. Esos binarios ya no funcionan en equipos de ahora — las versiones nuevas del sistema los fueron dejando atrás —, pero pude rescatar la capa web: en el fondo, una app híbrida así es una web embebida dentro del contenedor móvil. Ese mismo frontend lo desplegué como sitio estático en [Cloudflare Pages](https://pages.cloudflare.com/) en [kdosensei.xergioalex.com](https://kdosensei.xergioalex.com/), y reuní los archivos recuperados en el repositorio [xergioalex/kdosensei](https://github.com/xergioalex/kdosensei) — una cápsula del tiempo de ese semestre, el equipo y el tooling híbrido, conservada en vez de perderse en un zip olvidado de algún disco viejo.
 
 No cerré el capítulo ahí. En los años siguientes probé [Ionic](https://ionicframework.com/) — mismo espíritu, mejor tooling, prototipos más rápidos —, **Meteor** empaquetado con Cordova (reactivo y tentador hasta que en producción se sentía frágil) y también algún experimento con **React Native**, más cercano a lo nativo pero con fricciones propias. Cada intento me enseñó el techo del anterior.
 
@@ -111,9 +111,7 @@ Una app web se ejecuta dentro del navegador, un entorno relativamente predecible
 
 No es que el desarrollo web no tenga complejidad — la tiene, sea backend o frontend. Es que la complejidad es diferente: el instinto que te formaste manejando peticiones o reactividad de componentes no se traslada directamente a este dominio, porque el runtime ya no es tuyo — es del sistema operativo.
 
-Es un patrón que voy a encontrar una y otra vez en esta serie: los instintos del desarrollo web son válidos, pero no se trasladan directamente. Parte de aprender mobile es aprender cuándo confiar en lo que ya sabes y cuándo ponerlo en pausa.
-
-Eso dicho: el framework sí importa. Y hay demasiados para elegir sin entender primero el terreno.
+Dicho esto: el framework sí importa, y es bueno entender primero el terreno antes de elegir.
 
 ## Cuatro categorías antes de la lista
 


### PR DESCRIPTION
## Summary
- Link the recovered KDoSensei web assets to the [xergioalex/kdosensei](https://github.com/xergioalex/kdosensei) repo from the *Mobile Development in 2026* post, framed as a time-machine snapshot of the 2013 semester.
- Trim a redundant meta-paragraph about web instincts and tighten the lead-in to the framework discussion ("it's worth understanding the terrain before choosing" / "es bueno entender primero el terreno antes de elegir").
- Both EN and ES versions kept in sync.

## Test plan
- [ ] `npm run dev` and open `/blog/mobile-development-landscape-2026/` (EN) and `/es/blog/mobile-development-landscape-2026/` (ES); confirm the kdosensei repo link renders and the framework lead-in reads cleanly.
- [ ] `npm run biome:check` passes.
- [ ] `npm run astro:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)