### PR TITLE
chore(blog): add cloudflare tag to AEO isitagentready post

### DIFF
--- a/src/content/blog/en/2026-05-14_aeo-reaching-100-isitagentready.md
+++ b/src/content/blog/en/2026-05-14_aeo-reaching-100-isitagentready.md
@@ -4,7 +4,7 @@ description: "Five categories, eight artifacts, one concrete guide: what your si
 pubDate: "2026-05-14T15:00:00"
 heroImage: "/images/blog/posts/aeo-reaching-100-isitagentready/hero.webp"
 heroLayout: "side-by-side"
-tags: ["tech", "web-development", "ai-agents", "mcp"]
+tags: ["tech", "web-development", "ai-agents", "cloudflare", "mcp"]
 keywords: ["isitagentready.com 100", "agent-ready website", "well-known api-catalog", "oauth protected resource metadata", "mcp server card", "webmcp provideContext", "cloudflare pages headers RFC 8288", "content signals robots.txt", "lighthouse robots-txt", "x402 payment protocol", "agentic commerce protocol acp", "machine payment protocol mpp"]
 series: "aeo-from-invisible-to-cited"
 seriesOrder: 5

--- a/src/content/blog/es/2026-05-14_aeo-reaching-100-isitagentready.md
+++ b/src/content/blog/es/2026-05-14_aeo-reaching-100-isitagentready.md
@@ -4,7 +4,7 @@ description: "Cinco categorías, ocho artefactos, una guía: lo que tu web neces
 pubDate: "2026-05-14T15:00:00"
 heroImage: "/images/blog/posts/aeo-reaching-100-isitagentready/hero-es.webp"
 heroLayout: "side-by-side"
-tags: ["tech", "web-development", "ai-agents", "mcp"]
+tags: ["tech", "web-development", "ai-agents", "cloudflare", "mcp"]
 keywords: ["isitagentready.com 100", "sitio listo para agentes", "well-known api-catalog", "oauth protected resource metadata", "mcp server card", "webmcp provideContext", "cloudflare pages headers RFC 8288", "content signals robots.txt", "lighthouse robots-txt", "protocolo de pago x402", "agentic commerce protocol acp", "machine payment protocol mpp"]
 series: "aeo-from-invisible-to-cited"
 seriesOrder: 5


### PR DESCRIPTION
## Summary
- Add the `cloudflare` tag to the "Reaching 100 on isitagentready.com" post (EN + ES).
- Brings its tag set into parity with the two sibling posts in the AEO series (`cloudflare-agents-week-2026`, `aeo-well-known-field-guide`), which already use the same five tags.

Final tag set: `["tech", "web-development", "ai-agents", "cloudflare", "mcp"]` — 1 primary + 2 secondary + 2 subtopics, within taxonomy limits.

## Test plan
- [ ] Post renders with all five tags
- [ ] Tag pages list this post under `/tags/cloudflare`
- [ ] EN and ES versions stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)