### PR TITLE
content(blog): unpublish supply-chain-attacks-ai-era post (draft mode)

### DIFF
--- a/src/content/blog/en/2026-05-19_supply-chain-attacks-ai-era.md
+++ b/src/content/blog/en/2026-05-19_supply-chain-attacks-ai-era.md
@@ -6,7 +6,7 @@ tags: ["tech", "devops", "ai", "javascript"]
 keywords: ["supply chain attack 2026", "npm pnpm minimumReleaseAge", "Shai-Hulud worm", "tj-actions changed-files CVE-2025-30066", "slopsquatting", "axios npm compromise 2026", "Bitwarden CLI malicious 2026.4.0", "TanStack npm postmortem", "PyPI Trusted Publishing", "open source security 2026"]
 heroImage: "/images/blog/posts/supply-chain-attacks-ai-era/hero.webp"
 heroLayout: banner
-draft: false
+draft: true
 ---
 
 Eight days ago, [42 npm packages under `@tanstack/*` were compromised](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) inside a six-minute window. Three weeks before that, [Bitwarden's CLI on npm](https://www.paloaltonetworks.com/blog/cloud-security/bitwardencli-supply-chain-attack/) was hijacked for ninety minutes — and the payload specifically probed for installed AI coding assistants. Last month: [axios](https://socket.dev/blog/axios-npm-package-compromised), a package with over 100 million weekly downloads. Last quarter: [the YOLO library on PyPI](https://www.reversinglabs.com/blog/compromised-ultralytics-pypi-package-delivers-crypto-coinminer). Last September: [the first true self-replicating worm in npm's history](https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised), infecting hundreds of packages in days.

--- a/src/content/blog/es/2026-05-19_supply-chain-attacks-ai-era.md
+++ b/src/content/blog/es/2026-05-19_supply-chain-attacks-ai-era.md
@@ -6,7 +6,7 @@ tags: ["tech", "devops", "ai", "javascript"]
 keywords: ["ataque cadena de suministro 2026", "qué es minimumReleaseAge pnpm", "gusano Shai-Hulud npm", "CVE-2025-30066 tj-actions", "slopsquatting paquetes alucinados", "compromiso axios npm 2026", "Bitwarden CLI malicioso", "postmortem TanStack npm", "PyPI Trusted Publishing", "seguridad open source 2026"]
 heroImage: "/images/blog/posts/supply-chain-attacks-ai-era/hero.webp"
 heroLayout: banner
-draft: false
+draft: true
 ---
 
 Hace ocho días, [42 paquetes de npm bajo `@tanstack/*` fueron comprometidos](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) dentro de una ventana de seis minutos. Tres semanas antes, [el CLI de Bitwarden en npm](https://www.paloaltonetworks.com/blog/cloud-security/bitwardencli-supply-chain-attack/) fue secuestrado por noventa minutos — y el payload buscaba específicamente asistentes de IA para programar instalados en la máquina. El mes pasado: [axios](https://socket.dev/blog/axios-npm-package-compromised), un paquete con más de 100 millones de descargas semanales. El trimestre pasado: [la librería YOLO en PyPI](https://www.reversinglabs.com/blog/compromised-ultralytics-pypi-package-delivers-crypto-coinminer). En septiembre pasado: [el primer gusano auto-replicante real en la historia de npm](https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised), infectando cientos de paquetes en cuestión de días.


### PR DESCRIPTION
## Summary
- Set `draft: true` on both EN and ES versions of the `supply-chain-attacks-ai-era` blog post to temporarily remove it from the live site while iterating.
- No content changes — only the frontmatter `draft` flag.

## Test plan
- [ ] `pnpm run build` succeeds locally
- [ ] After merge + deploy, `https://xergioalex.com/blog/supply-chain-attacks-ai-era/` returns 404 (or is excluded from listings)
- [ ] Post still accessible in dev mode via `_demo` / draft preview if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)