### PR TITLE
content(blog): trim slide-system intro to match the restructured ES body

### DIFF
--- a/src/content/blog/es/2026-05-25_building-slide-system-inside-astro-revealjs.md
+++ b/src/content/blog/es/2026-05-25_building-slide-system-inside-astro-revealjs.md
@@ -18,7 +18,7 @@ La meta era concreta: quería que mis charlas vivieran en el mismo lugar que mi 
 
 Y había una segunda condición: que el sistema se pudiera pilotar con agentes de IA. Si las slides son texto plano —archivos `.md` en el repo— un agente puede generar una, reordenar una sección o traducir un deck entero igual que edita cualquier otro archivo, y yo me quedo con lo que de verdad importa: la narrativa.
 
-Este post es el caso de estudio de cómo lo construí: las decisiones de arquitectura, los dos tipos de presentaciones que el sistema soporta, y los problemas que solo aparecieron cuando empecé a usarlo frente a audiencias reales.
+Este post es el caso de estudio de cómo lo construí: las decisiones de arquitectura y los dos tipos de presentaciones que el sistema soporta.
 
 ## ¿Por qué Reveal.js?
 


### PR DESCRIPTION
## Summary

One-line trim to the ES version of the slide-system post.

The intro promised three threads ("decisiones de arquitectura, los dos tipos de presentaciones que el sistema soporta, y los problemas que solo aparecieron cuando empecé a usarlo frente a audiencias reales"), but the third thread — the "problemas con audiencias reales" section — was dropped during the ES restructure weeks ago. Trimming the intro so it lines up with what the body now delivers.

EN is intentionally not touched: its body still has `## The Problems That Only Show Up With an Audience`, so its intro is still accurate.

## Test plan

- [x] One-line edit; no schema or rendering changes
- [ ] After merge, eyeball the ES post intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)