### PR TITLE
feat: subtle sponsor links on blog author card and contact page

### DIFF
--- a/src/components/blog/AuthorCard.astro
+++ b/src/components/blog/AuthorCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { Language } from '@/lib/i18n';
+import { getTranslations } from '@/lib/translations';
 
 interface Props {
   author: {
@@ -13,12 +14,14 @@ interface Props {
       github?: string;
       instagram?: string;
       website?: string;
+      sponsor?: string;
     };
   };
   lang: Language;
 }
 
 const { author, lang } = Astro.props;
+const t = getTranslations(lang);
 
 const authorRole =
   (author.role as Record<string, string>)[lang] ?? author.role.en;
@@ -88,6 +91,24 @@ const socialLinks = [
               </svg>
             </a>
           ))}
+        </div>
+      )}
+      {author.social?.sponsor && (
+        <div class="mt-3 flex justify-center sm:justify-start">
+          <a
+            href={author.social.sponsor}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-700"
+            aria-label={t.nav.sponsor}
+            data-umami-event="sponsor_click"
+            data-umami-event-source="author_card"
+          >
+            <svg class="h-4 w-4 text-[#bf3989] dark:text-[#db61a2]" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+              <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002Z" />
+            </svg>
+            {t.nav.sponsor}
+          </a>
         </div>
       )}
       <slot />

--- a/src/components/blog/BlogPostFooter.astro
+++ b/src/components/blog/BlogPostFooter.astro
@@ -28,6 +28,7 @@ let author:
         github?: string;
         instagram?: string;
         website?: string;
+        sponsor?: string;
       };
     }
   | undefined;

--- a/src/components/pages/ContactPage.astro
+++ b/src/components/pages/ContactPage.astro
@@ -140,7 +140,27 @@ const breadcrumbSchema = {
     </div>
   </PageSection>
 
-  <PageSection title={t.contactPage.locationTitle}>
+  <PageSection title={t.contactPage.sponsorTitle}>
+    <div class="max-w-2xl mx-auto text-center">
+      <p class="text-base sm:text-lg text-gray-600 dark:text-gray-300 mb-6">{t.contactPage.sponsorText}</p>
+      <a
+        href="https://github.com/sponsors/xergioalex"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-white font-medium transition-colors"
+        aria-label={t.footer.sponsor}
+        data-umami-event="sponsor_click"
+        data-umami-event-source="contact"
+      >
+        <svg class="w-5 h-5 text-[#bf3989] dark:text-[#db61a2]" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002Z"/>
+        </svg>
+        {t.footer.sponsor}
+      </a>
+    </div>
+  </PageSection>
+
+  <PageSection title={t.contactPage.locationTitle} background="gray">
     <p class="text-base sm:text-lg text-gray-600 dark:text-gray-300">{t.contactPage.locationText}</p>
   </PageSection>
 </MainLayout>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -147,6 +147,7 @@ const authors = defineCollection({
         github: z.string().optional(),
         instagram: z.string().optional(),
         website: z.string().optional(),
+        sponsor: z.string().optional(),
       })
       .optional(),
   }),

--- a/src/content/authors/sergio-florez.yaml
+++ b/src/content/authors/sergio-florez.yaml
@@ -13,3 +13,4 @@ social:
   github: https://github.com/xergioalex
   instagram: https://www.instagram.com/xergioalex
   website: https://xergioalex.com/
+  sponsor: https://github.com/sponsors/xergioalex

--- a/src/content/pages/en/contact.md
+++ b/src/content/pages/en/contact.md
@@ -30,6 +30,14 @@ Always open to new opportunities, collaborations, and conversations. Whether you
 
 ---
 
+## Support My Work
+
+If my articles, open-source projects, or talks have helped you, you can sponsor my work on GitHub. It directly funds more free writing and open-source.
+
+- [Sponsor on GitHub](https://github.com/sponsors/xergioalex)
+
+---
+
 ## Location
 
 Based in Colombia. Open to remote collaboration worldwide.

--- a/src/content/pages/es/contact.md
+++ b/src/content/pages/es/contact.md
@@ -30,6 +30,14 @@ Siempre abierto a nuevas oportunidades, colaboraciones y conversaciones. Ya sea 
 
 ---
 
+## Apoya mi trabajo
+
+Si mis artículos, proyectos open source o charlas te han servido, puedes patrocinar mi trabajo en GitHub. Ayuda directamente a que siga escribiendo y creando open source de forma gratuita.
+
+- [Patrocinar en GitHub](https://github.com/sponsors/xergioalex)
+
+---
+
 ## Ubicación
 
 Ubicado en Colombia. Abierto a colaboración remota en todo el mundo.

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -867,6 +867,9 @@ I currently focus on AI applications, developer productivity, and high-impact pr
     socialTitle: 'Connect With Me',
     locationTitle: 'Location',
     locationText: 'Based in Colombia. Open to remote collaboration worldwide.',
+    sponsorTitle: 'Support My Work',
+    sponsorText:
+      'If my articles, open-source projects, or talks have helped you, you can sponsor my work on GitHub. It directly funds more free writing and open-source — thank you!',
     prefillSubjects: {
       generalInquiry: 'General Inquiry',
       collaboration: 'Collaboration Opportunity',

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -875,6 +875,9 @@ Actualmente estoy enfocado en aplicaciones de IA, productividad para developers 
     locationTitle: 'Ubicaci\u00F3n',
     locationText:
       'Ubicado en Colombia. Abierto a colaboraci\u00F3n remota en todo el mundo.',
+    sponsorTitle: 'Apoya mi trabajo',
+    sponsorText:
+      'Si mis art\u00EDculos, proyectos open source o charlas te han servido, puedes patrocinar mi trabajo en GitHub. Ayuda directamente a que siga escribiendo y creando open source de forma gratuita. \u00A1Gracias!',
     prefillSubjects: {
       generalInquiry: 'Consulta General',
       collaboration: 'Oportunidad de Colaboración',

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -396,6 +396,8 @@ export interface SiteTranslations {
     socialTitle: string;
     locationTitle: string;
     locationText: string;
+    sponsorTitle: string;
+    sponsorText: string;
     prefillSubjects: {
       generalInquiry: string;
       collaboration: string;


### PR DESCRIPTION
## What

Adds **subtle** GitHub Sponsors entry points in two high-intent, blog-relevant places, complementing the existing header/footer sponsor buttons.

### 1. Blog author card (end of every post)
- New **optional** `sponsor` field on the author social schema — the link only renders for authors who set it (today: only `sergio-florez`). Guest authors are unaffected.
- A small, subtle "Sponsor" pill with the GitHub Sponsors pink heart appears under the author's social icons.
- Rationale: highest-intent moment is right after a reader finishes a free article; it's contextual ("support the person who wrote this").

### 2. Contact page
- New **"Support My Work"** section with a short message + sponsor button, placed between the social links and location.
- Rationale: visitors here already intend to connect; a low-pressure support option fits naturally.

## Why
Sponsorship helps fund the unpaid work — especially **free, in-depth technical writing** and open-source. These placements are deliberately subtle (no banners, popups, or mid-article CTAs).

## Implementation notes
- `sponsor` is optional in the Zod schema → zero impact on other authors.
- Full i18n: `contactPage.sponsorTitle` / `sponsorText` in both `en.ts` and `es.ts` (+ `types.ts`).
- Contact agent markdown (`src/content/pages/{en,es}/contact.md`) kept in sync.
- Analytics: `sponsor_click` event with `source` (`author_card` / `contact`).
- Button styling matches the GitHub Sponsors look already used in header/footer.

## Validation
- ✅ `pnpm run biome:check`
- ✅ `pnpm run astro:check` (0 errors)
- ✅ `pnpm run build` (394 pages)
- ✅ `pnpm run md:check` (all HTML pages have matching .md)
- ✅ Spanish diacritics verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)