### PR TITLE
content(blog): SEO + AEO refinements for Trunks four-timelines post

### DIFF
--- a/src/content/blog/en/2026-07-22_dragon-ball-z-trunks-and-the-four-timelines.md
+++ b/src/content/blog/en/2026-07-22_dragon-ball-z-trunks-and-the-four-timelines.md
@@ -1,5 +1,5 @@
 ---
-title: 'The Tangled Timelines of Dragon Ball Z: Trunks and the Four Histories'
+title: 'Dragon Ball Z: Trunks and the Four Timelines'
 description: 'Trunks travels back to save his friends and accidentally creates four timelines — the perfect, messy finale for a series about messing with time.'
 pubDate: '2026-07-22'
 heroImage: '/images/blog/posts/dragon-ball-z-trunks-and-the-four-timelines/hero.webp'
@@ -19,7 +19,7 @@ People argue about the exact count online to this day. Let me walk through it, b
 
 ---
 
-## The setup
+## The setup: why Future Trunks travels back in time
 
 Future Trunks comes from a ruined world. In his future, Goku has died of a heart virus, and two androids — 17 and 18 — have spent years murdering the Z Fighters and everyone else, leaving the planet a graveyard. Trunks and his mentor Gohan are among the last defenders, until Gohan dies too.
 
@@ -27,7 +27,7 @@ So his mother, Bulma, builds a time machine. Trunks travels back roughly twenty 
 
 ---
 
-## The rule of the Dragon Ball universe
+## The rule: time travel creates a new timeline
 
 Here's the key, and it's exactly the branching model from the last post: in *Dragon Ball*, **traveling to the past doesn't overwrite history — it creates a new, parallel timeline.** Trunks can hand Goku the medicine and change everything that follows, but he changes it in a *new* branch. His own ruined future stays ruined. Nothing he does in the past saves the world he came from.
 
@@ -35,7 +35,9 @@ The series is unusually honest about this, and it's why the bookkeeping gets com
 
 ---
 
-## The four timelines
+## The four timelines of Dragon Ball Z, explained
+
+The short version: counting every trip across time, *Dragon Ball Z* runs on **four timelines**. Here's each one, in the order they branch.
 
 **Timeline 1 — the original.** Goku dies of the heart virus, the androids rampage, the Z Fighters fall, and eventually the monster Cell rises too. No time travel has touched this history yet. This is the baseline, the worst version of events, the one everything else branches away from.
 
@@ -49,7 +51,7 @@ Four histories, all sprouting from one act of mercy. A young man tried to save h
 
 ---
 
-## Why this is the perfect ending for the series
+## Why four timelines is the perfect ending for the series
 
 Look at what *Dragon Ball Z* gets right — better, honestly, than a lot of "serious" science fiction.
 

--- a/src/content/blog/es/2026-07-22_dragon-ball-z-trunks-and-the-four-timelines.md
+++ b/src/content/blog/es/2026-07-22_dragon-ball-z-trunks-and-the-four-timelines.md
@@ -1,5 +1,5 @@
 ---
-title: 'Las líneas temporales enredadas de Dragon Ball Z: Trunks y las cuatro historias'
+title: 'Dragon Ball Z: Trunks y las cuatro líneas temporales'
 description: 'Trunks viaja al pasado para salvar a sus amigos y crea sin querer cuatro líneas temporales. El final perfecto y enredado para una serie sobre el tiempo.'
 pubDate: '2026-07-22'
 heroImage: '/images/blog/posts/dragon-ball-z-trunks-and-the-four-timelines/hero.webp'
@@ -19,7 +19,7 @@ La gente todavía discute el conteo exacto en internet. Déjame recorrerlo, porq
 
 ---
 
-## El planteamiento
+## El planteamiento: por qué Trunks del futuro viaja al pasado
 
 Trunks del futuro viene de un mundo arruinado. En su futuro, Goku ha muerto de un virus en el corazón, y dos androides — el 17 y el 18 — se han pasado años asesinando a los Guerreros Z y a todos los demás, dejando el planeta hecho un cementerio. Trunks y su maestro Gohan están entre los últimos defensores, hasta que Gohan también muere.
 
@@ -27,7 +27,7 @@ Así que su madre, Bulma, construye una máquina del tiempo. Trunks viaja unos v
 
 ---
 
-## La regla del universo de Dragon Ball
+## La regla: viajar al pasado crea una nueva línea temporal
 
 Aquí está la clave, y es exactamente el modelo de la bifurcación del artículo anterior: en *Dragon Ball*, **viajar al pasado no sobrescribe la historia — crea una nueva línea temporal paralela.** Trunks puede entregarle la medicina a Goku y cambiar todo lo que sigue, pero lo cambia en una *nueva* rama. Su propio futuro arruinado sigue arruinado. Nada de lo que hace en el pasado salva el mundo del que vino.
 
@@ -35,7 +35,9 @@ La serie es inusualmente honesta con esto, y por eso la contabilidad se complica
 
 ---
 
-## Las cuatro líneas temporales
+## Las cuatro líneas temporales de Dragon Ball Z, explicadas
+
+La versión corta: contando cada viaje a través del tiempo, *Dragon Ball Z* corre sobre **cuatro líneas temporales**. Aquí está cada una, en el orden en que se bifurcan.
 
 **Línea temporal 1 — la original.** Goku muere del virus del corazón, los androides arrasan, los Guerreros Z caen y con el tiempo también surge el monstruo Cell. Ningún viaje en el tiempo ha tocado esta historia todavía. Es la base, la peor versión de los hechos, de la que todo lo demás se desprende.
 
@@ -49,7 +51,7 @@ Cuatro historias, todas brotando de un solo acto de misericordia. Un joven inten
 
 ---
 
-## Por qué este es el final perfecto para la serie
+## Por qué cuatro líneas temporales son el final perfecto para la serie
 
 Mira lo que *Dragon Ball Z* hace bien — mejor, honestamente, que mucha ciencia ficción "seria".
 


### PR DESCRIPTION
## Summary

SEO and AEO refinements for the **Dragon Ball Z: Trunks and the Four Timelines** post (`/blog/dragon-ball-z-trunks-and-the-four-timelines/`), in both EN and ES. The post stays in `draft: true` — this is **pre-release** content, so the PR is opened as a draft.

## Changes

**SEO**
- Tightened titles to front-load the primary keyword and fit the 60-char target:
  - EN: `The Tangled Timelines of Dragon Ball Z: Trunks and the Four Histories` (69) → `Dragon Ball Z: Trunks and the Four Timelines` (44)
  - ES: `Las líneas temporales enredadas de Dragon Ball Z: Trunks y las cuatro historias` (80) → `Dragon Ball Z: Trunks y las cuatro líneas temporales` (53)
  - New titles align with the URL slug and the `keywords` frontmatter.
- Descriptions left unchanged (already within 130–160 chars: EN 147, ES 153).

**AEO**
- Rewrote section headings to mirror real answer-engine queries while keeping the series' statement-heading style:
  - `The setup` → `The setup: why Future Trunks travels back in time`
  - `The rule of the Dragon Ball universe` → `The rule: time travel creates a new timeline`
  - `The four timelines` → `The four timelines of Dragon Ball Z, explained`
  - `Why this is the perfect ending...` → `Why four timelines is the perfect ending...`
- Added a one-line **direct answer** under the four-timelines heading so answer engines can lift "Dragon Ball Z runs on four timelines" verbatim (matches the `how many timelines in DBZ` keyword).

## Validation
- `pnpm run build` ✓ (416 pages)
- Heading parity preserved (5 `##` per language)
- ES orthography / no-voseo ✓, no placeholder content ✓
- Post remains `draft: true` (per request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)