### PR TITLE
fix: make OAuth Protected Resource Metadata discoverable from auth.md

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -44,8 +44,8 @@ For agents that probe the standard OAuth discovery surface, the site publishes
 spec-shaped metadata. These are **reserved, non-active stubs** — the site has no
 live OAuth flows today:
 
-- Protected Resource Metadata — [`/.well-known/oauth-protected-resource`](/.well-known/oauth-protected-resource)
-- Authorization Server Metadata — [`/.well-known/oauth-authorization-server`](/.well-known/oauth-authorization-server)
+- Protected Resource Metadata (RFC 9728) — [https://xergioalex.com/.well-known/oauth-protected-resource](https://xergioalex.com/.well-known/oauth-protected-resource)
+- Authorization Server Metadata (RFC 8414) — [https://xergioalex.com/.well-known/oauth-authorization-server](https://xergioalex.com/.well-known/oauth-authorization-server)
   - Includes an `agent_auth` block advertising an `anonymous` identity type and
     a reserved `register_uri`.
 


### PR DESCRIPTION
## Problem

isitagentready.com auth.md check reports:

> auth.md exists but **OAuth Protected Resource Metadata was not found**

…even though `/.well-known/oauth-protected-resource` is **live, valid JSON, served as `application/json`**, and the standalone `oauth-protected-resource` check passes.

## Root cause

The **standalone** PRM check fetches `/.well-known/oauth-protected-resource` directly (passes). The **auth.md** check is different: it verifies that `/auth.md` itself *points to* the OAuth metadata and follows that link. The live `auth.md` referenced the PRM with a **root-relative URL wrapped in an inline code span**:

```md
- Protected Resource Metadata — [`/.well-known/oauth-protected-resource`](/.well-known/oauth-protected-resource)
```

Strict markdown link extractors mis-resolve or skip that, so the checker can't locate the PRM from `auth.md` → "not found".

## Fix (covers both documented discovery paths)

1. **Absolute links in `auth.md`** — the PRM and Authorization Server links are now absolute and free of code-span wrapping, so any parser resolves them unambiguously.
2. **`WWW-Authenticate` header** (RFC 9728 §5.1) — root pages now send `WWW-Authenticate: Bearer resource_metadata="https://xergioalex.com/.well-known/oauth-protected-resource"`, giving agents the header-based discovery path too. Advisory on 200 responses (browsers only act on 401), so safe for a static site.

No change to the metadata JSON documents — they are already correct and live.

## Verification
- [x] `auth.md` links absolute (`grep` confirms)
- [x] `_headers` advertises `resource_metadata` on `/` and `/es/`
- [x] Live PRM/AS already 200 `application/json`, valid, with `agent_auth`
- [ ] Merge + deploy, then **re-scan** isitagentready.com → expect auth.md check green → score 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)