### PR TITLE
fix: non-empty scopes_supported — the real auth.md / PRM blocker

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -6,7 +6,7 @@
   "jwks_uri": "https://xergioalex.com/.well-known/jwks.json",
   "grant_types_supported": ["authorization_code"],
   "response_types_supported": ["code"],
-  "scopes_supported": [],
+  "scopes_supported": ["read"],
   "token_endpoint_auth_methods_supported": ["none"],
   "agent_auth": {
     "_comment": "Reserved, non-active stub for agent-readiness compliance (Auth.md convention). xergioalex.com is a static, public, read-only site: agents access all content anonymously with no registration. These endpoints are reserved paths and do not currently accept requests — do not probe them during passive scans.",
@@ -16,6 +16,9 @@
     "claim_uri": "https://xergioalex.com/agent/auth/claim",
     "claim_endpoint": "https://xergioalex.com/agent/auth/claim",
     "identity_types_supported": ["anonymous"],
+    "anonymous": {
+      "credential_types_supported": ["bearer"]
+    },
     "credential_types_supported": ["bearer"]
   }
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -2,6 +2,6 @@
   "_comment": "xergioalex.com is a static content site with no OAuth-protected resources today. This document is published for agent-readiness compliance per RFC 9728 and the Auth.md convention. The authorization_servers entry self-references the site's own OAuth authorization-server metadata (also a stub).",
   "resource": "https://xergioalex.com",
   "authorization_servers": ["https://xergioalex.com"],
-  "scopes_supported": [],
+  "scopes_supported": ["read"],
   "bearer_methods_supported": ["header"]
 }


### PR DESCRIPTION
## Root cause (verified against the live scanner, not guessed)

I called the scanner's own API directly:

```
POST https://isitagentready.com/api/scan {"url":"https://xergioalex.com"}
```

and read the `checks…authMd` **evidence trail**. The Protected Resource Metadata **is fetched fine** — 200, `application/json`. The failing step is validation:

```json
{ "action": "validate",
  "label": "Validate Protected Resource Metadata",
  "finding": { "outcome": "negative", "summary": "Missing scopes_supported array" } }
```

The checker treats **`scopes_supported: []` (empty array) as missing**, then surfaces the misleading top-level message *"OAuth Protected Resource Metadata was not found."* That's why every previous fix (absolute auth.md links, WWW-Authenticate header) had no effect — the document was always found; it just failed validation on the empty scopes array.

## Fix

- `/.well-known/oauth-protected-resource`: `scopes_supported` → `["read"]`
- `/.well-known/oauth-authorization-server`: `scopes_supported` → `["read"]`; align `agent_auth` with the SKILL's anonymous flow (`anonymous.credential_types_supported`)

## Why this is the one

The scan reported exactly one negative finding for `authMd`, and it was the empty scopes array. With `resource`, `authorization_servers`, `bearer_methods_supported:["header"]` already valid, a non-empty `scopes_supported` is the last missing piece.

## After merge + deploy
Re-scan → `authMd` should pass → **API/Auth 7/7 → score 100** (Discoverability already 4/4 after the DNS-AID records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)