### PR TITLE
feat: Markdown access line for agents + faster dev-container prompt

### DIFF
--- a/docker/custom_commands.sh
+++ b/docker/custom_commands.sh
@@ -244,6 +244,13 @@ function git_status_indicator() {
     fi
 }
 
+# Cached git dirty state for the prompt. `git status` costs ~0.4s on the
+# macOS bind mount even with core.untrackedCache, so refresh at most every
+# 5 seconds instead of on every prompt redraw.
+__GIT_DIRTY_CACHE=""
+__GIT_DIRTY_REPO=""
+__GIT_DIRTY_TS=-10
+
 # Custom PS1 prompt with colors and git info
 function set_bash_prompt() {
     local exit_code=$?
@@ -257,7 +264,9 @@ function set_bash_prompt() {
 
     # Get git branch and status
     local git_info=""
-    if git rev-parse --git-dir > /dev/null 2>&1; then
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [[ -n "$repo_root" ]]; then
         local branch
         branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
@@ -265,8 +274,17 @@ function set_bash_prompt() {
             branch='detached*'
         fi
 
-        # Check if there are uncommitted changes
-        if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+        if [[ "$repo_root" != "$__GIT_DIRTY_REPO" ]] || (( SECONDS - __GIT_DIRTY_TS >= 5 )); then
+            if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+                __GIT_DIRTY_CACHE=1
+            else
+                __GIT_DIRTY_CACHE=0
+            fi
+            __GIT_DIRTY_REPO="$repo_root"
+            __GIT_DIRTY_TS=$SECONDS
+        fi
+
+        if [[ "$__GIT_DIRTY_CACHE" == 1 ]]; then
             git_info=" ${red}(${branch}*)${reset}"
         else
             git_info=" ${green}(${branch})${reset}"

--- a/docs/aeo/MARKDOWN_FOR_AGENTS.md
+++ b/docs/aeo/MARKDOWN_FOR_AGENTS.md
@@ -48,6 +48,17 @@ Source: `post.body` from Astro content collection (raw Markdown without frontmat
 
 Source: `src/content/pages/{en,es}/` content collection.
 
+### Slides
+
+| Pattern | Description |
+|---------|-------------|
+| `/slides/{slug}.md` (EN) | A single deck — metadata header + deck body |
+| `/es/slides/{slug}.md` (ES) | Spanish twin |
+| `/slides/index.md` (EN) | Lists all EN decks with `.md` links |
+| `/es/slides/index.md` (ES) | Lists all ES decks with `.md` links |
+
+Source: `src/content/slides/{en,es}/` content collection. Metadata keys stay in English across languages (agents parse one format); only section headings and the body follow the deck's language.
+
 ## Response Format
 
 ```markdown
@@ -59,6 +70,7 @@ Published: 2026-03-09
 Updated: 2026-03-10
 Language: en
 Canonical: https://xergioalex.com/blog/post-slug
+Markdown: send header `Accept: text/markdown` on any URL to receive Markdown instead of HTML.
 Tags: tag1, tag2
 
 ---
@@ -70,6 +82,7 @@ Tags: tag1, tag2
 - Blockquote description — visually distinct
 - Simple key-value metadata — easy to parse
 - Canonical URL — always points to the HTML version
+- Markdown access line — tells agents to send `Accept: text/markdown` on any URL for Markdown instead of HTML. Emitted by `buildMarkdownAccessLine(lang)`, always immediately after `Canonical:`, localized per language (the header name and media type stay literal so agents can parse them). See [Content Negotiation](#content-negotiation-via-accept-textmarkdown).
 - Separator before body — clear content boundary
 - Site navigation footer — global nav links appended to every output (see below)
 
@@ -96,7 +109,13 @@ Tags: tag1, tag2
 - `serializePostToAgentMarkdown(post, { slug, lang })` — blog posts
 - `serializeBlogIndexToMarkdown(entries, { lang, title, description })` — blog index
 - `serializeSeriesIndexToMarkdown(entries, { slug, seriesTitle, seriesDescription, lang })` — series index
+- `serializeSeriesListingToMarkdown(entries, { lang, title, description })` — series landing page
 - `serializePageToAgentMarkdown(page, { slug, lang })` — non-blog pages
+- `serializeSlideDeckToMarkdown(deck, { slug, lang })` — slide decks
+- `serializeSlidesIndexToMarkdown(entries, { lang, title, description })` — slides index
+- `buildMarkdownAccessLine(lang)` — the Markdown access line; the single source of that string
+
+**Rule:** every serializer that emits a metadata header MUST call `buildMarkdownAccessLine(lang)` immediately after its `Canonical:` line. Never hardcode the string in a route file — routes call serializers, and the helper lives only in the shared module. A new serializer without the access line is a defect.
 
 ### Site Navigation Partial
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -32,7 +32,9 @@ authenticate before using a site's resources.
 ## What agents can do without registering
 
 - Read any HTML page (`https://xergioalex.com/…`) and its Spanish twin (`/es/…`).
-- Read the Markdown-for-agents twin of any page (append `.md` to the path).
+- Read the Markdown-for-agents twin of any page — either append `.md` to the
+  path, or send the header `Accept: text/markdown` on any URL to receive
+  Markdown instead of HTML.
 - Read `/.well-known/api-catalog`, `/openapi.json`, `/llms.txt`, and
   `/llms-full.txt` for a machine-readable map of the site.
 - Discover skills via `/.well-known/agent-skills/index.json` and the MCP

--- a/src/lib/markdown-for-agents.ts
+++ b/src/lib/markdown-for-agents.ts
@@ -137,6 +137,21 @@ function buildUrlPrefix(lang: string): string {
 }
 
 /**
+ * One-line hint included in every .md mirror header so agents know how to
+ * fetch Markdown for any other URL on the site via content negotiation
+ * (see functions/_middleware.ts), without appending `.md` or parsing HTML.
+ *
+ * The header name and media type stay literal in every language — agents
+ * parse those tokens. Only the surrounding prose is localized.
+ */
+export function buildMarkdownAccessLine(lang: string): string {
+  if (lang === 'es') {
+    return 'Markdown: envía el header `Accept: text/markdown` en cualquier URL para recibir Markdown en lugar de HTML.';
+  }
+  return 'Markdown: send header `Accept: text/markdown` on any URL to receive Markdown instead of HTML.';
+}
+
+/**
  * Serialize a blog post to agent-friendly Markdown.
  * Returns clean Markdown with metadata header + original body.
  */
@@ -162,6 +177,7 @@ export function serializePostToAgentMarkdown(
   }
   lines.push(`Language: ${lang}`);
   lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
   if (tags && tags.length > 0) {
     lines.push(`Tags: ${tags.join(', ')}`);
   }
@@ -201,6 +217,7 @@ export function serializeBlogIndexToMarkdown(
   lines.push('');
   lines.push(`Language: ${lang}`);
   lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
   lines.push(`Total posts: ${entries.length}`);
   lines.push('');
   lines.push('---');
@@ -257,6 +274,7 @@ export function serializeSeriesIndexToMarkdown(
   }
   lines.push(`Language: ${lang}`);
   lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
   lines.push(`Total chapters: ${entries.length}`);
   lines.push('');
   lines.push('---');
@@ -311,6 +329,7 @@ export function serializeSeriesListingToMarkdown(
   lines.push('');
   lines.push(`Language: ${lang}`);
   lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
   lines.push(`Total series: ${entries.length}`);
   lines.push('');
   lines.push('---');
@@ -324,6 +343,141 @@ export function serializeSeriesListingToMarkdown(
     const chapterCount = `${entry.postCount} ${entry.postCount === 1 ? 'chapter' : 'chapters'}`;
     lines.push(
       `- [${entry.title}](${seriesMdUrl}) — ${entry.description} (${chapterCount})`
+    );
+  }
+
+  lines.push(generateSiteNavigation(lang));
+
+  return `${lines.join('\n')}\n`;
+}
+
+interface SlideDeckSerializeOptions {
+  slug: string;
+  lang: string;
+}
+
+interface SlidesIndexEntry {
+  title: string;
+  slug: string;
+  description: string;
+  type: string;
+  pubDate: Date;
+  eventName?: string;
+}
+
+interface SlidesIndexOptions {
+  lang: string;
+  title: string;
+  description: string;
+}
+
+/**
+ * Serialize a slide deck to agent-friendly Markdown.
+ * Metadata keys stay in English across languages so agents parse one format;
+ * only section headings and the body follow the deck's language.
+ */
+export function serializeSlideDeckToMarkdown(
+  deck: CollectionEntry<'slides'>,
+  options: SlideDeckSerializeOptions
+): string {
+  const { slug, lang } = options;
+  const data = deck.data;
+  const prefix = buildUrlPrefix(lang);
+  const canonicalUrl = `${SITE_URL}${prefix}/slides/${slug}`;
+
+  const lines: string[] = [];
+
+  lines.push(`# ${data.title}`);
+  lines.push('');
+  lines.push(`> ${data.description}`);
+  lines.push('');
+  lines.push(`Language: ${lang}`);
+  lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
+  lines.push(`Type: ${data.type}`);
+  lines.push(`Published: ${formatDate(data.pubDate)}`);
+  if (data.updatedDate) {
+    lines.push(`Updated: ${formatDate(data.updatedDate)}`);
+  }
+  if (data.eventName) {
+    let event = `Event: ${data.eventName}`;
+    if (data.eventDate) {
+      event += ` (${formatDate(data.eventDate)})`;
+    }
+    if (data.eventUrl) {
+      event += ` — ${data.eventUrl}`;
+    }
+    lines.push(event);
+  }
+  if (data.relatedPost) {
+    lines.push(`Related post: ${SITE_URL}${prefix}/blog/${data.relatedPost}`);
+  }
+  lines.push('Author: Sergio Alexander Florez Galeano (XergioAleX)');
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  if (data.type === 'external') {
+    const heading =
+      lang === 'es' ? 'Presentación Externa' : 'External Presentation';
+    lines.push(`## ${heading}`);
+    lines.push('');
+    lines.push(`- **URL:** ${data.externalUrl}`);
+    if (data.provider) {
+      const providerLabel = lang === 'es' ? 'Proveedor' : 'Provider';
+      lines.push(`- **${providerLabel}:** ${data.provider}`);
+    }
+    lines.push('');
+  }
+
+  if (deck.body?.trim()) {
+    const heading = lang === 'es' ? 'Contenido' : 'Content';
+    lines.push(`## ${heading}`);
+    lines.push('');
+    lines.push(deck.body.trim());
+  }
+
+  lines.push(generateSiteNavigation(lang));
+
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Serialize the slides listing to agent-friendly Markdown.
+ * Returns a list of decks with links to their .md versions.
+ */
+export function serializeSlidesIndexToMarkdown(
+  entries: SlidesIndexEntry[],
+  options: SlidesIndexOptions
+): string {
+  const { lang, title, description } = options;
+  const prefix = buildUrlPrefix(lang);
+  const canonicalUrl = `${SITE_URL}${prefix}/slides`;
+
+  const lines: string[] = [];
+
+  lines.push(`# ${title}`);
+  lines.push('');
+  lines.push(`> ${description}`);
+  lines.push('');
+  lines.push(`Language: ${lang}`);
+  lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
+  lines.push(`Total decks: ${entries.length}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(`## ${lang === 'es' ? 'Presentaciones' : 'Decks'}`);
+  lines.push('');
+
+  for (const entry of entries) {
+    const deckMdUrl = `${prefix}/slides/${entry.slug}.md`;
+    const parts = [`${entry.type}`, formatDate(entry.pubDate)];
+    if (entry.eventName) {
+      parts.push(entry.eventName);
+    }
+    lines.push(
+      `- [${entry.title}](${deckMdUrl}) — ${entry.description} (${parts.join(', ')})`
     );
   }
 
@@ -354,6 +508,7 @@ export function serializePageToAgentMarkdown(
   lines.push('');
   lines.push(`Language: ${lang}`);
   lines.push(`Canonical: ${canonicalUrl}`);
+  lines.push(buildMarkdownAccessLine(lang));
 
   if ('lastUpdated' in page.data && page.data.lastUpdated instanceof Date) {
     lines.push(`Last Updated: ${formatDate(page.data.lastUpdated)}`);

--- a/src/pages/es/slides/[slug].md.ts
+++ b/src/pages/es/slides/[slug].md.ts
@@ -1,5 +1,6 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 
+import { serializeSlideDeckToMarkdown } from '@/lib/markdown-for-agents';
 import { getDeckSlug, getSlideDecks } from '@/lib/slides';
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -10,47 +11,13 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-export const GET: APIRoute = ({ props }) => {
+export const GET: APIRoute = ({ props, params }) => {
   const { deck } = props;
-  const data = deck.data;
-  let markdown = '';
 
-  markdown += `# ${data.title}\n\n`;
-  markdown += `> ${data.description}\n\n`;
-
-  // Bloque de metadatos (legible por agentes)
-  markdown += '## Metadatos\n\n';
-  markdown += `- **Tipo:** ${data.type}\n`;
-  markdown += `- **Idioma:** es\n`;
-  markdown += `- **Publicado:** ${data.pubDate.toISOString().split('T')[0]}\n`;
-  if (data.updatedDate) {
-    markdown += `- **Actualizado:** ${data.updatedDate.toISOString().split('T')[0]}\n`;
-  }
-  if (data.eventName) {
-    markdown += `- **Evento:** ${data.eventName}`;
-    if (data.eventDate) {
-      markdown += ` (${data.eventDate.toISOString().split('T')[0]})`;
-    }
-    if (data.eventUrl) markdown += ` — ${data.eventUrl}`;
-    markdown += '\n';
-  }
-  if (data.relatedPost) {
-    markdown += `- **Artículo relacionado:** /es/blog/${data.relatedPost}\n`;
-  }
-  markdown += '- **Autor:** Sergio Alexander Florez Galeano (XergioAleX)\n';
-  markdown += '\n';
-
-  if (data.type === 'external') {
-    markdown += '## Presentación Externa\n\n';
-    markdown += `- **URL:** ${data.externalUrl}\n`;
-    if (data.provider) markdown += `- **Proveedor:** ${data.provider}\n`;
-    markdown += '\n';
-  }
-
-  if (deck.body?.trim()) {
-    markdown += '## Contenido\n\n';
-    markdown += deck.body;
-  }
+  const markdown = serializeSlideDeckToMarkdown(deck, {
+    slug: params.slug as string,
+    lang: 'es',
+  });
 
   return new Response(markdown, {
     headers: {

--- a/src/pages/es/slides/index.md.ts
+++ b/src/pages/es/slides/index.md.ts
@@ -1,24 +1,27 @@
 import type { APIRoute } from 'astro';
 
+import { serializeSlidesIndexToMarkdown } from '@/lib/markdown-for-agents';
 import { getDeckSlug, getSlideDecks } from '@/lib/slides';
 
 export const GET: APIRoute = async () => {
   const decks = await getSlideDecks('es');
 
-  let markdown = '# Diapositivas — Presentaciones\n\n';
-  markdown +=
-    '> Una colección de presentaciones de Sergio Alexander — charlas de conferencias, slides de meetups y deep dives técnicos.\n\n';
-
-  for (const deck of decks) {
-    const slug = getDeckSlug(deck.id);
-    markdown += `## [${deck.data.title}](/es/slides/${slug})\n\n`;
-    markdown += `> ${deck.data.description}\n\n`;
-    markdown += `- **Tipo:** ${deck.data.type}\n`;
-    markdown += `- **Fecha:** ${deck.data.pubDate.toISOString().split('T')[0]}\n`;
-    if (deck.data.eventName)
-      markdown += `- **Evento:** ${deck.data.eventName}\n`;
-    markdown += '\n---\n\n';
-  }
+  const markdown = serializeSlidesIndexToMarkdown(
+    decks.map((deck) => ({
+      title: deck.data.title,
+      slug: getDeckSlug(deck.id),
+      description: deck.data.description,
+      type: deck.data.type,
+      pubDate: deck.data.pubDate,
+      eventName: deck.data.eventName,
+    })),
+    {
+      lang: 'es',
+      title: 'Diapositivas — Presentaciones',
+      description:
+        'Una colección de presentaciones de Sergio Alexander — charlas de conferencias, slides de meetups y deep dives técnicos.',
+    }
+  );
 
   return new Response(markdown, {
     headers: {

--- a/src/pages/slides/[slug].md.ts
+++ b/src/pages/slides/[slug].md.ts
@@ -1,5 +1,6 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 
+import { serializeSlideDeckToMarkdown } from '@/lib/markdown-for-agents';
 import { getDeckSlug, getSlideDecks } from '@/lib/slides';
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -10,50 +11,13 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-export const GET: APIRoute = ({ props }) => {
+export const GET: APIRoute = ({ props, params }) => {
   const { deck } = props;
-  const data = deck.data;
-  let markdown = '';
 
-  // Title and description
-  markdown += `# ${data.title}\n\n`;
-  markdown += `> ${data.description}\n\n`;
-
-  // Metadata block (machine-readable for AI agents)
-  markdown += '## Metadata\n\n';
-  markdown += `- **Type:** ${data.type}\n`;
-  markdown += `- **Language:** en\n`;
-  markdown += `- **Published:** ${data.pubDate.toISOString().split('T')[0]}\n`;
-  if (data.updatedDate) {
-    markdown += `- **Updated:** ${data.updatedDate.toISOString().split('T')[0]}\n`;
-  }
-  if (data.eventName) {
-    markdown += `- **Event:** ${data.eventName}`;
-    if (data.eventDate) {
-      markdown += ` (${data.eventDate.toISOString().split('T')[0]})`;
-    }
-    if (data.eventUrl) markdown += ` — ${data.eventUrl}`;
-    markdown += '\n';
-  }
-  if (data.relatedPost) {
-    markdown += `- **Related post:** /blog/${data.relatedPost}\n`;
-  }
-  markdown += '- **Author:** Sergio Alexander Florez Galeano (XergioAleX)\n';
-  markdown += '\n';
-
-  // Type-specific fields
-  if (data.type === 'external') {
-    markdown += '## External Presentation\n\n';
-    markdown += `- **URL:** ${data.externalUrl}\n`;
-    if (data.provider) markdown += `- **Provider:** ${data.provider}\n`;
-    markdown += '\n';
-  }
-
-  // Body — full slide content for internal decks, supplementary copy for externals
-  if (deck.body?.trim()) {
-    markdown += '## Content\n\n';
-    markdown += deck.body;
-  }
+  const markdown = serializeSlideDeckToMarkdown(deck, {
+    slug: params.slug as string,
+    lang: 'en',
+  });
 
   return new Response(markdown, {
     headers: {

--- a/src/pages/slides/index.md.ts
+++ b/src/pages/slides/index.md.ts
@@ -1,24 +1,27 @@
 import type { APIRoute } from 'astro';
 
+import { serializeSlidesIndexToMarkdown } from '@/lib/markdown-for-agents';
 import { getDeckSlug, getSlideDecks } from '@/lib/slides';
 
 export const GET: APIRoute = async () => {
   const decks = await getSlideDecks('en');
 
-  let markdown = '# Slides — Presentation Decks\n\n';
-  markdown +=
-    '> A collection of presentation decks by Sergio Alexander — conference talks, meetup slides, and technical deep dives.\n\n';
-
-  for (const deck of decks) {
-    const slug = getDeckSlug(deck.id);
-    markdown += `## [${deck.data.title}](/slides/${slug})\n\n`;
-    markdown += `> ${deck.data.description}\n\n`;
-    markdown += `- **Type:** ${deck.data.type}\n`;
-    markdown += `- **Date:** ${deck.data.pubDate.toISOString().split('T')[0]}\n`;
-    if (deck.data.eventName)
-      markdown += `- **Event:** ${deck.data.eventName}\n`;
-    markdown += '\n---\n\n';
-  }
+  const markdown = serializeSlidesIndexToMarkdown(
+    decks.map((deck) => ({
+      title: deck.data.title,
+      slug: getDeckSlug(deck.id),
+      description: deck.data.description,
+      type: deck.data.type,
+      pubDate: deck.data.pubDate,
+      eventName: deck.data.eventName,
+    })),
+    {
+      lang: 'en',
+      title: 'Slides — Presentation Decks',
+      description:
+        'A collection of presentation decks by Sergio Alexander — conference talks, meetup slides, and technical deep dives.',
+    }
+  );
 
   return new Response(markdown, {
     headers: {

--- a/tests/unit/lib/markdown-for-agents.test.ts
+++ b/tests/unit/lib/markdown-for-agents.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildMarkdownAccessLine,
   serializeBlogIndexToMarkdown,
   serializePageToAgentMarkdown,
   serializePostToAgentMarkdown,
+  serializeSeriesIndexToMarkdown,
+  serializeSeriesListingToMarkdown,
+  serializeSlideDeckToMarkdown,
+  serializeSlidesIndexToMarkdown,
 } from '@/lib/markdown-for-agents';
+
+/** The one canonical EN access line — pinned so it can never drift. */
+const EN_ACCESS_LINE =
+  'Markdown: send header `Accept: text/markdown` on any URL to receive Markdown instead of HTML.';
+const ES_ACCESS_LINE =
+  'Markdown: envía el header `Accept: text/markdown` en cualquier URL para recibir Markdown en lugar de HTML.';
 
 // ─── Mock Data ─────────────────────────────────────────
 
@@ -268,5 +279,288 @@ describe('serializePageToAgentMarkdown', () => {
     });
 
     expect(result).not.toContain('Last Updated:');
+  });
+});
+
+// ─── buildMarkdownAccessLine ───────────────────────────
+
+describe('buildMarkdownAccessLine', () => {
+  it('should return the canonical EN line', () => {
+    expect(buildMarkdownAccessLine('en')).toBe(EN_ACCESS_LINE);
+  });
+
+  it('should return the localized ES line with diacritics', () => {
+    const line = buildMarkdownAccessLine('es');
+
+    expect(line).toBe(ES_ACCESS_LINE);
+    expect(line).toContain('envía');
+    expect(line).toContain('en lugar de HTML');
+  });
+
+  it('should keep the header name and media type literal in every language', () => {
+    for (const lang of ['en', 'es']) {
+      expect(buildMarkdownAccessLine(lang)).toContain(
+        '`Accept: text/markdown`'
+      );
+    }
+  });
+
+  it('should fall back to English for unknown languages', () => {
+    expect(buildMarkdownAccessLine('pt')).toBe(EN_ACCESS_LINE);
+    expect(buildMarkdownAccessLine('')).toBe(EN_ACCESS_LINE);
+  });
+
+  it('should document negotiation only, never the .md suffix path', () => {
+    expect(buildMarkdownAccessLine('en')).not.toContain('append `.md`');
+    expect(buildMarkdownAccessLine('es')).not.toContain('.md');
+  });
+});
+
+// ─── Markdown access line across all serializers ───────
+
+describe('markdown access line placement', () => {
+  const mockDeck = {
+    id: 'en/2024-08-01_my-deck',
+    data: {
+      type: 'native',
+      title: 'My Deck',
+      description: 'A test deck.',
+      pubDate: new Date('2024-08-01'),
+      eventName: 'PyCon',
+    },
+    body: '## Slide One\n\nHello.',
+  };
+
+  /** Every serializer family, invoked with minimal valid input. */
+  const serializers: Array<[string, (lang: string) => string]> = [
+    [
+      'serializePostToAgentMarkdown',
+      (lang) =>
+        serializePostToAgentMarkdown(mockPost as any, {
+          slug: 'my-awesome-post',
+          lang,
+        }),
+    ],
+    [
+      'serializeBlogIndexToMarkdown',
+      (lang) =>
+        serializeBlogIndexToMarkdown([], {
+          lang,
+          title: 'Blog',
+          description: 'Test.',
+        }),
+    ],
+    [
+      'serializeSeriesIndexToMarkdown',
+      (lang) =>
+        serializeSeriesIndexToMarkdown([], {
+          slug: 'my-series',
+          seriesTitle: 'My Series',
+          seriesDescription: 'Test series.',
+          lang,
+        }),
+    ],
+    [
+      'serializeSeriesListingToMarkdown',
+      (lang) =>
+        serializeSeriesListingToMarkdown([], {
+          lang,
+          title: 'Series',
+          description: 'All series.',
+        }),
+    ],
+    [
+      'serializePageToAgentMarkdown',
+      (lang) =>
+        serializePageToAgentMarkdown(mockPage as any, { slug: 'about', lang }),
+    ],
+    [
+      'serializeSlideDeckToMarkdown',
+      (lang) =>
+        serializeSlideDeckToMarkdown(mockDeck as any, {
+          slug: 'my-deck',
+          lang,
+        }),
+    ],
+    [
+      'serializeSlidesIndexToMarkdown',
+      (lang) =>
+        serializeSlidesIndexToMarkdown([], {
+          lang,
+          title: 'Slides',
+          description: 'All decks.',
+        }),
+    ],
+  ];
+
+  for (const [name, serialize] of serializers) {
+    describe(name, () => {
+      it('should include the exact EN access line', () => {
+        expect(serialize('en')).toContain(EN_ACCESS_LINE);
+      });
+
+      it('should include the localized ES access line', () => {
+        expect(serialize('es')).toContain(ES_ACCESS_LINE);
+      });
+
+      it('should place the access line immediately after Canonical:', () => {
+        const lines = serialize('en').split('\n');
+        const canonicalIndex = lines.findIndex((l) =>
+          l.startsWith('Canonical:')
+        );
+
+        expect(canonicalIndex).toBeGreaterThan(-1);
+        expect(lines[canonicalIndex + 1]).toBe(EN_ACCESS_LINE);
+      });
+
+      it('should emit the access line exactly once', () => {
+        const occurrences = serialize('en')
+          .split('\n')
+          .filter((l) => l.startsWith('Markdown: '));
+
+        expect(occurrences).toHaveLength(1);
+      });
+    });
+  }
+});
+
+// ─── Slides serializers ────────────────────────────────
+
+describe('serializeSlideDeckToMarkdown', () => {
+  const mockNativeDeck = {
+    id: 'en/2024-08-01_my-deck',
+    data: {
+      type: 'native',
+      title: 'My Deck',
+      description: 'A test deck.',
+      pubDate: new Date('2024-08-01'),
+      updatedDate: new Date('2024-09-01'),
+      eventName: 'PyCon',
+      eventDate: new Date('2024-08-05'),
+      eventUrl: 'https://pycon.org',
+      relatedPost: 'my-awesome-post',
+    },
+    body: '## Slide One\n\nHello.',
+  };
+
+  const mockExternalDeck = {
+    id: 'es/2024-10-01_external-deck',
+    data: {
+      type: 'external',
+      title: 'Charla Externa',
+      description: 'Una presentación alojada fuera del sitio.',
+      pubDate: new Date('2024-10-01'),
+      externalUrl: 'https://slides.com/deck',
+      provider: 'Slides.com',
+    },
+    body: undefined,
+  };
+
+  it('should produce correct output with all fields', () => {
+    const result = serializeSlideDeckToMarkdown(mockNativeDeck as any, {
+      slug: 'my-deck',
+      lang: 'en',
+    });
+
+    expect(result).toContain('# My Deck');
+    expect(result).toContain('> A test deck.');
+    expect(result).toContain('Language: en');
+    expect(result).toContain(
+      'Canonical: https://xergioalex.com/slides/my-deck'
+    );
+    expect(result).toContain('Type: native');
+    expect(result).toContain('Published: 2024-08-01');
+    expect(result).toContain('Updated: 2024-09-01');
+    expect(result).toContain('Event: PyCon (2024-08-05) — https://pycon.org');
+    expect(result).toContain(
+      'Related post: https://xergioalex.com/blog/my-awesome-post'
+    );
+    expect(result).toContain('## Content');
+    expect(result).toContain('## Slide One');
+  });
+
+  it('should render external deck fields and ES canonical URL', () => {
+    const result = serializeSlideDeckToMarkdown(mockExternalDeck as any, {
+      slug: 'external-deck',
+      lang: 'es',
+    });
+
+    expect(result).toContain(
+      'Canonical: https://xergioalex.com/es/slides/external-deck'
+    );
+    expect(result).toContain('Type: external');
+    expect(result).toContain('## Presentación Externa');
+    expect(result).toContain('- **URL:** https://slides.com/deck');
+    expect(result).toContain('- **Proveedor:** Slides.com');
+    expect(result).not.toContain('## Contenido');
+  });
+
+  it('should end with a trailing newline', () => {
+    const result = serializeSlideDeckToMarkdown(mockNativeDeck as any, {
+      slug: 'my-deck',
+      lang: 'en',
+    });
+
+    expect(result.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('serializeSlidesIndexToMarkdown', () => {
+  const entries = [
+    {
+      title: 'First Deck',
+      slug: 'first-deck',
+      description: 'The first deck.',
+      type: 'native',
+      pubDate: new Date('2024-08-01'),
+      eventName: 'PyCon',
+    },
+    {
+      title: 'Second Deck',
+      slug: 'second-deck',
+      description: 'The second deck.',
+      type: 'external',
+      pubDate: new Date('2024-09-01'),
+    },
+  ];
+
+  it('should produce correct index structure with .md links', () => {
+    const result = serializeSlidesIndexToMarkdown(entries, {
+      lang: 'en',
+      title: 'Slides — Presentation Decks',
+      description: 'A collection of decks.',
+    });
+
+    expect(result).toContain('# Slides — Presentation Decks');
+    expect(result).toContain('Canonical: https://xergioalex.com/slides');
+    expect(result).toContain('Total decks: 2');
+    expect(result).toContain(
+      '[First Deck](/slides/first-deck.md) — The first deck. (native, 2024-08-01, PyCon)'
+    );
+    expect(result).toContain(
+      '[Second Deck](/slides/second-deck.md) — The second deck. (external, 2024-09-01)'
+    );
+  });
+
+  it('should use ES prefix for Spanish index', () => {
+    const result = serializeSlidesIndexToMarkdown(entries, {
+      lang: 'es',
+      title: 'Diapositivas',
+      description: 'Colección de presentaciones.',
+    });
+
+    expect(result).toContain('Canonical: https://xergioalex.com/es/slides');
+    expect(result).toContain('## Presentaciones');
+    expect(result).toContain('/es/slides/first-deck.md');
+  });
+
+  it('should handle empty entries list', () => {
+    const result = serializeSlidesIndexToMarkdown([], {
+      lang: 'en',
+      title: 'Slides',
+      description: 'No decks yet.',
+    });
+
+    expect(result).toContain('Total decks: 0');
   });
 });


### PR DESCRIPTION
Two unrelated improvements bundled per request: an AEO change to the agent Markdown layer, and a dev-container prompt performance fix. They touch disjoint files, and each is its own commit.

## 1. Markdown access line (`feat(aeo)`)

Every agent-facing Markdown response now carries this line immediately after `Canonical:`:

```text
Markdown: send header `Accept: text/markdown` on any URL to receive Markdown instead of HTML.
```

An agent that lands on one `.md` page previously had no machine-readable hint for how to get Markdown for *any other* URL without appending `.md` or scraping HTML. This documents the content-negotiation contract that `functions/_middleware.ts` already implements.

- `buildMarkdownAccessLine(lang)` in `src/lib/markdown-for-agents.ts` is the **single source** of the string. No route file hardcodes it.
- The site ships **en/es only**, so those are localized and anything else falls back to English. The header name and media type stay literal in every language so agents can parse those tokens.

**Note — the slides routes got a real refactor.** `slides/index.md.ts`, `slides/[slug].md.ts` and their `es/` twins built Markdown by hand and had **no `Canonical:` line at all**, so there was nowhere to anchor the hint. Rather than invent a second header format, they now use shared serializers (`serializeSlideDeckToMarkdown`, `serializeSlidesIndexToMarkdown`). This removes the duplicated en/es logic (~110 lines of route code) and gives decks the standard header plus the site-navigation footer every other page already had. Their metadata keys are now English in both languages, matching the blog/page serializers.

### Verification

`pnpm run test` (259 pass), `biome:check`, `astro:check` (0 errors), `build` (416 pages) all green.

Checked every generated file rather than sampling: **310 of 313** `.md` files in `dist/` contain the line. The three that don't are correct — two are incidental README/prompt files under `public/images/`, and `auth.md` follows the separate Auth.md convention and has no `Canonical:` header. It already told agents to "append `.md`", so negotiation is mentioned alongside that existing claim.

**Not verified end-to-end:** wrangler isn't available in the container, so `Accept: text/markdown` wasn't exercised against a live edge runtime. `functions/_middleware.ts` is untouched and serves the same static `.md` assets that were verified, so negotiation returns the identical body by construction — but that's reasoning, not an observed request. Worth a `curl -H 'Accept: text/markdown'` after deploy.

## 2. Faster dev-container prompt (`perf(docker)`)

`set_bash_prompt` ran `git status --porcelain` on **every prompt redraw**, even on an empty Enter. The project dir is a macOS bind mount (`fakeowner` over `/run/host_mark`), where the untracked-files walk is slow — so every Enter blocked for ~3s.

The dirty check is now cached with a **5s TTL**, keyed by repo root so switching repos in the same shell refreshes immediately instead of showing another repo's state.

**Tradeoff (accepted):** the red/green dirty indicator may lag up to 5s. Branch name and path are always current.

### Measured here (1,488 tracked files)

| Command | Time |
| --- | --- |
| `git status --porcelain` (cold walk, populating cache) | 3.03s |
| `git status --porcelain` with `core.untrackedCache` | ~0.15–0.20s |
| `set_bash_prompt` first call | ~35ms |
| `set_bash_prompt` cached | ~8–10ms |

Behavior verified beyond timings: clean repo renders green; a repo dirtied within the TTL correctly shows the stale green; after TTL expiry it refreshes to red; switching repos refreshes immediately without waiting for the TTL; a non-repo directory renders no git info.

### ⚠️ This PR only carries half of that fix

Part 1 is `git config core.untrackedcache true`, which is stored in `.git/config` — **not tracked by git**, so it cannot ship in a PR. I've applied it to this clone only.

Anyone else (fresh clone or container rebuild) keeps the ~3s cold walk until they run it themselves:

```bash
git config core.untrackedcache true
```

If you want it to apply for everyone automatically, it should go into the container setup rather than being a manual step — happy to do that in a follow-up. `core.fsmonitor` was deliberately **not** enabled: it adds nothing on this kind of bind mount and its daemon may receive unreliable events through the mount.

### To take effect

```bash
source docker/custom_commands.sh   # or open a new terminal
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
