### PR TITLE
docs(readme): tighten Overview heading, add badges, document missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-## ✨ Overview.
+## ✨ Overview
 
 A modern, fast, and fully bilingual personal website built with [Astro](https://astro.build). It serves as a professional portfolio, blog platform, and personal brand presence — showcasing experience, projects, and thought leadership.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Visit **http://localhost:4444** to preview.
 | `pnpm run test` | Run unit tests (Vitest) |
 | `pnpm run test:watch` | Vitest in watch mode |
 | `pnpm run test:coverage` | Tests with coverage report |
+| `pnpm run test:e2e` | Run end-to-end tests (Playwright) |
+| `pnpm run test:e2e:ui` | Open the Playwright test runner UI |
 | `pnpm run images:optimize` | Convert staged images to WebP |
 | `pnpm run md:check` | Verify HTML / Markdown agent-endpoint parity |
 | `pnpm run search:budgets` | Check search index performance budgets |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Visit **http://localhost:4444** to preview.
 | `pnpm run test:e2e:ui` | Open the Playwright test runner UI |
 | `pnpm run images:optimize` | Convert staged images to WebP |
 | `pnpm run md:check` | Verify HTML / Markdown agent-endpoint parity |
+| `pnpm run md:check:strict` | Same as above but exits `1` on missing files (CI mode) |
 | `pnpm run search:budgets` | Check search index performance budgets |
 | `pnpm run lighthouse` | Run Lighthouse CI audit |
 | `pnpm run ncu:check` | Check for dependency updates |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Code Check](https://github.com/xergioalex/xergioalex.com/actions/workflows/code_check.yml/badge.svg)](https://github.com/xergioalex/xergioalex.com/actions/workflows/code_check.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Astro](https://img.shields.io/badge/Astro-6.x-FF5D01?logo=astro)](https://astro.build)
+[![Node.js](https://img.shields.io/badge/Node.js-24+-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+[![pnpm](https://img.shields.io/badge/pnpm-11.x-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)
 
 [🌐 Live Site](https://xergioalex.com) · [📖 Architecture](./docs/ARCHITECTURE.md) · [📋 Product Spec](./docs/PRODUCT_SPEC.md)
 


### PR DESCRIPTION
## Summary

Small, low-risk polish pass over the top-level `README.md`:

- Drop the stray period from the `## Overview` heading.
- Add **Node.js 24+** and **pnpm 11.x** badges to the header row so they match what Quick Start already requires.
- Document the Playwright end-to-end commands (`test:e2e`, `test:e2e:ui`) that already live in `package.json` but were missing from the Commands table.
- Document `md:check:strict` (CI variant of the Markdown/HTML parity check) alongside the existing `md:check` entry.

No source, config, or content changes — only `README.md`.

## Test plan

- [ ] `README.md` renders correctly on GitHub (badges load, tables align, no broken headings).
- [ ] Every added command exists in `package.json#scripts` (`test:e2e`, `test:e2e:ui`, `md:check:strict`).
- [ ] No other files touched: `git diff --stat main...docs/readme-improvements` shows only `README.md`.


Made with [Cursor](https://cursor.com)