### PR TITLE
feat: add "When Colombia Shook" earthquake series (draft)

### DIFF
--- a/src/content/blog/en/2026-08-17_the-day-pereira-went-quiet.md
+++ b/src/content/blog/en/2026-08-17_the-day-pereira-went-quiet.md
@@ -1,0 +1,140 @@
+---
+title: 'The Day Pereira Went Quiet'
+description: 'On August 10, 2026, a magnitude 7.4 earthquake hit western Colombia. Pereira, my city, was one of the hardest hit. What happened, with every figure sourced.'
+pubDate: '2026-08-17'
+tags: ['personal', 'colombia', 'tech']
+keywords: ['2026 Colombia earthquake', 'Pereira earthquake August 2026', 'San José del Palmar Chocó earthquake', 'Colombia earthquake death toll', 'Pereira buildings collapsed', 'how long did the Colombia earthquake last', 'UNGRD earthquake balance']
+series: 'colombia-earthquake-2026'
+seriesOrder: 1
+draft: true
+---
+
+Monday, August 10, 2026. 7:34 in the morning.
+
+The [Servicio Geológico Colombiano](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx) says the shaking lasted somewhere between ninety seconds and two minutes. I haven't met anyone in Pereira who remembers it as under five.
+
+I live here. And a week later I still don't have a clean way to describe what the city looks like, so I'm going to borrow the only sentence that has felt accurate to me: a lot of Pereira feels destroyed, or unrecognizable, and a lot of people need help. That's not a statistic. It's what it feels like to walk around, and I'm going to keep those two things separate for this entire series — what I feel and what I can prove.
+
+This is the first of six articles about the earthquake and about what a few hundred developers did in the days after it. I want to start with the part that isn't about software at all.
+
+---
+
+## What actually happened
+
+The epicenter was near **San José del Palmar**, in Chocó, about 20 km from the town. Magnitude **7.4**. Depth **103 km** according to the SGC — the USGS puts it slightly deeper, at 110 km. In the first hours you saw 82 km and 96 km circulating. Those were early estimates that got revised, which is worth remembering, because it's the first small example of a pattern that shaped everything else that week.
+
+The depth is the whole story of why this one felt different.
+
+This wasn't a shallow fault rupturing under a city. Off the Pacific coast, the Nazca plate slides underneath the South American plate — subduction, the same process that built the Andes. This earthquake happened *inside* that descending slab, more than a hundred kilometers down. The USGS classifies it as strike-slip faulting within the plate rather than a rupture along the plate boundary.
+
+Which means: the energy came from far below and spread out over an enormous area instead of concentrating in one valley. Over **12,000 people from 900 population centers** reported feeling it, according to the SGC. It was felt in Panama. It was felt in Venezuela. And it went on and on, because — in the SGC's words — when the magnitude is that high, the energy released can't fully dissipate before it reaches the surface.
+
+It's the strongest earthquake recorded in Colombia this century.
+
+Then the aftershocks started. Eighteen by noon on the first day. [More than 130 by six in the morning on August 12](https://www.infobae.com/colombia/2026/08/12/tras-el-terremoto-de-74-en-colombia-ya-son-130-las-replicas-confirmo-el-servicio-geologico-colombiano/), ranging from 0.6 to 4.8, clustered around San José del Palmar and Sipí. On the 13th it shook hard again in Chocó in the middle of the night.
+
+The aftershocks are the reason people stopped sleeping indoors. They're also the reason that every piece of information about whether a building was safe had a shelf life measured in hours.
+
+---
+
+## The numbers, and why they keep moving
+
+I want to be careful here, because this is where a lot of writing about disasters quietly goes wrong.
+
+Between August 10 and August 15, the official figures changed every day and sometimes several times a day. Different entities — the UNGRD, Asocapitales, individual mayors' offices, governors — published different consolidated counts at the same moment. Not because anyone was lying. Because each one cut off at a different hour, and for the first days there was no single national consolidation.
+
+Here's the shape of it:
+
+| Cut-off | Deaths | Injured | Missing |
+|---------|--------|---------|---------|
+| Aug 10 (preliminary, Asocapitales) | 132 | 570 | — |
+| Aug 12 (UNGRD) | 239 | 3,755 | 287 |
+| Aug 13 (UNGRD) | 281 | 3,971 | 379 |
+| **Aug 15, 6:30 p.m. (UNGRD)** | **289** | **3,937** | **143** |
+
+Fifteen departments. Four hundred fifty municipalities.
+
+Look at the last column. Missing persons went from 379 down to 143 in two days.
+
+That drop is not a correction of somebody's mistake. It's several hundred people being found — reunited with family, located in a shelter, identified. It is, in the most literal sense, the result of human beings cross-referencing lists. I'll come back to that in this series, because some of that cross-referencing happened in software that didn't exist the week before.
+
+By department, at the August 13 cut: Valle del Cauca 125, **Risaralda 94**, Chocó 14, Caldas 6, Quindío 3, Antioquia 1. According to Asocapitales, capital cities accounted for roughly 75% of the dead. This was an urban disaster.
+
+---
+
+## Pereira
+
+[El Tiempo called it the hardest-hit city](https://www.eltiempo.com/justicia/investigacion/pereira-la-ciudad-mas-golpeada-por-el-terremoto-al-menos-67-victimas-mortales-3577462), and the building count is why.
+
+The city government's early report: **66 buildings in total collapse, 26 in partial collapse**, plus hundreds of damaged homes. Later reporting put the number above 80. Two hundred forty-three people rescued. Two hundred seventy-nine moved to clinics and hospitals. Fourteen animals pulled out.
+
+The Invico building on Avenida Circunvalar is the one everyone has seen. Its twelfth floor is simply gone. Three people were trapped in it and [couldn't be recovered](https://www.pulzo.com/nacion/terremoto-pereira-danos-edificio-invico-rescatados-balance-oficial-PP5272271), because there was no passage left between floors.
+
+Around 267 rescue workers were operating at once, local crews plus USAR teams sent from Bogotá, Envigado, Yopal and Medellín. Bogotá alone sent a hundred people. And alongside them, thousands of neighbors. In Los Álamos and Lorena, more than two hundred people gathered at two points and dug.
+
+Shelters opened at Parque El Vergel, Parque El Oso, Coliseo Mayor, Parque Olaya, Plaza de Ferias and Estadio Mora Mora. [Two of them hit capacity within days](https://www.semana.com/nacion/pereira/articulo/terremoto-en-pereira-dos-albergues-ya-estan-al-limite-y-estos-son-los-puntos-disponibles/202651/).
+
+Mayor Mauricio Salazar declared public calamity and economic emergency, imposed a curfew from six in the evening to five in the morning after reports of looting, and then banned private vehicle circulation entirely from midnight on the 12th until eight in the evening on the 17th. The building census started on the 12th.
+
+The displaced-family count is the figure that moved most. It began at "2,000, and we'll probably get to 4,000." It later reached **41,600 families, around 140,000 people affected**. Those aren't contradictory numbers — the first was people in shelters, the second is people whose homes were damaged. But if you see them quoted side by side without that distinction, they look like chaos, and they aren't.
+
+---
+
+## Three days without anything
+
+Most of the city lost water, power and internet at the same time, and stayed that way for about three days. Some sectors are still without, or intermittent, as I write this.
+
+Nationally, [Andesco reported 93% of electrical service restored](https://www.lafm.com.co/economia/terremoto-colombia-reestablecimiento-servicio-electrico-terremoto-407808) within days, and Pereira went from 75% to around 90%. Some sectors stayed dark on purpose, for safety, not for lack of capacity. Water came back progressively while crews inspected damaged distribution networks. Gas stayed off in several areas while leaks were controlled.
+
+The telecom failure is the one I keep thinking about as an engineer. According to MinTIC, **more than 3,400 mobile base stations went out of service** — 46.1% of the stations reviewed across seven departments. Nearly half the cell network in the affected region, gone.
+
+The ministry opened spectrum temporarily, made interconnection between operators mandatory so a call could exit through whichever network was still alive, and made emergency-line calls free for users with no balance. [Starlink offered free service until September 12](https://www.semana.com/tecnologia/articulo/starlink-anuncia-internet-satelital-gratis-a-colombia-tras-el-devastador-terremoto-asi-puede-recibirlo/202612/) and shipped equipment for response agencies. Antennas went up here.
+
+I mention all of this now because I'm going to spend later articles talking about apps, and I don't want to do that dishonestly. For the first days, a large part of the city had no way to load one.
+
+---
+
+## Everybody helped from wherever they were standing
+
+This is the part I did not expect, and it's the reason I'm writing at all.
+
+The collaboration that came out of this has been something else. Doctors did medicine. Restaurants cooked. People with trucks moved things. People with a spare room offered it. Students sorted donations in warehouses for entire days. Rescue workers went on far past the point where anyone would have called it reasonable — El Colombiano ran an interview with one of them under the headline *"Estoy donde me toque, lo más importante es ayudar"* ("I'll be wherever I'm needed, the important thing is to help"), and La Patria ran another one titled *"Estamos cansados pero satisfechos de ayudar"* ("We're exhausted but glad to be helping"). Those are their words, not mine.
+
+Everybody contributed from what they knew how to do.
+
+I don't know how to get anyone out of a collapsed building. I've never been more aware of that than in the last week. What I know how to do is build software.
+
+So that's what a lot of us did. Within days there were damage maps, supply-center dashboards, missing-person matching tools, shelter directories, even a classifieds board for lost pets. Some were built in hours. One of them, [Gravitas, was rebuilt for the emergency in 42 hours](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) by a design studio that until that week was working on rural tourism.
+
+I helped build the landing page for [Corag](https://corag.app/), where a team is working on connecting people who need something with people who can give it. And I started doing the thing that turns out to be my actual contribution: writing down who else is out there, so the pieces can find each other. That list lives at [corag.app/ecosystem](https://corag.app/ecosystem/).
+
+There are more than twenty of these tools now. A few days ago the people behind several of them sat down together to figure out how to stop duplicating each other. That conversation is what the rest of this series is about.
+
+---
+
+## A note on the numbers in this series
+
+Every figure in these articles carries a named source and a cut-off date. I'm doing that for a boring reason and an important one.
+
+The boring reason is that these numbers are still moving. Anything I write today will be wrong by some margin next month, and a number without a date is a number that quietly lies as it ages.
+
+The important one is that this whole series argues that trustworthy information matters — that timestamps and evidence are the difference between help arriving and help evaporating. I can't make that argument in an article that plays loose with its own facts.
+
+So: no invented percentages. No "half the city was destroyed." I feel like half the city was destroyed. That's a feeling, it's in the third paragraph of this post, and it's labeled as one.
+
+---
+
+## Resources
+
+- [Servicio Geológico Colombiano — official update on the San José del Palmar earthquake](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx)
+- [Chequeado — twelve questions and answers to understand what happened](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/)
+- [El Tiempo — official UNGRD balance](https://www.eltiempo.com/colombia/otras-ciudades/balance-oficial-de-la-ungrd-tras-terremoto-de-magnitud-7-4-en-colombia-273-fallecidos-3-824-heridos-y-377-desaparecidos-3578196)
+- [corag.app/ecosystem — directory of the aid apps built after the earthquake](https://corag.app/ecosystem/)
+
+---
+
+Pereira didn't go quiet for ninety seconds. It went quiet for three days — no power, no water, no signal, and a lot of people standing in the street because going back inside felt like a bet.
+
+What filled that silence, eventually, was people showing up with whatever they had.
+
+Let's keep building.

--- a/src/content/blog/en/2026-08-20_one-hundred-three-kilometers-down.md
+++ b/src/content/blog/en/2026-08-20_one-hundred-three-kilometers-down.md
@@ -1,0 +1,141 @@
+---
+title: 'One Hundred Three Kilometers Down'
+description: 'The 2026 earthquake released about 150 times more energy than the one that flattened Armenia in 1999, and killed far fewer people. Here is why that happened.'
+pubDate: '2026-08-20'
+tags: ['tech', 'personal', 'colombia']
+keywords: ['why was the Colombia earthquake so deep', 'Nazca plate subduction Colombia', 'NSR-10 seismic building code', 'Armenia 1999 earthquake comparison', 'intraplate earthquake explained', 'why do buildings collapse in earthquakes', 'Colombia earthquake HAARP hoax']
+series: 'colombia-earthquake-2026'
+seriesOrder: 2
+draft: true
+---
+
+Here's the question that has been bothering me since the numbers started settling.
+
+The earthquake on January 25, 1999 — the one people here just call *el del Eje Cafetero* — was magnitude 6.1. It killed **1,185 people**, injured more than 8,500, and left around 36,000 homes destroyed or uninhabitable across 28 municipalities. Armenia, the city at the center of it, was flattened.
+
+The earthquake on August 10, 2026 was magnitude 7.4. Because the magnitude scale is logarithmic, that gap is much bigger than it looks: the seismic moment released was roughly **150 times greater** than in 1999.
+
+And Armenia reported **zero deaths**. Ninety percent of its buildings were declared habitable.
+
+That's not luck. I went looking for the explanation, and it turns out there are two, and only one of them is geology.
+
+---
+
+## Why this one came from so far down
+
+Off Colombia's Pacific coast, the Nazca plate slides underneath the South American plate. That's subduction — the slow-motion collision that built the Andes and that gives this country roughly 2,500 seismic events a month.
+
+Most of the earthquakes that hurt people happen near the surface, where a fault ruptures a few kilometers under a city and the shaking is concentrated and violent in a small area. That's what 1999 was.
+
+This one was different. It happened *inside* the Nazca slab itself, more than a hundred kilometers down, long after that slab had already dived under the continent. The USGS reads it as strike-slip faulting within the descending plate, not a rupture along the boundary between plates.
+
+Depth changes everything about how an earthquake behaves at the surface:
+
+- **It spreads out.** Energy released 103 km down reaches the surface across a huge footprint instead of concentrating in one valley. That's why [more than 12,000 people in 900 population centers](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx) reported feeling it, and why it registered in Panama and Venezuela.
+- **It lasts.** Ninety seconds to two minutes, against the handful of seconds a shallow quake usually gives you.
+- **It doesn't break the surface.** No visible fault scarp, no tsunami.
+- **It's weaker per square kilometer.** The same energy divided over a much larger area means lower peak intensity anywhere in particular.
+
+The SGC put it plainly when people asked why something that deep was felt so widely: when the magnitude is that high, the energy released can't fully dissipate before reaching the surface.
+
+The maximum intensity recorded was **VIII on the Modified Mercalli scale** — severe. The SGC reported 7 on the EMS-98 scale, which also means severe damage. The peak ground acceleration measured in Jamundí was 0.427 g.
+
+So: a much bigger earthquake, spread much thinner. That's explanation number one, and it's the one that gets repeated. It's real, and it's incomplete.
+
+---
+
+## The four things that decide whether a building falls
+
+[Chequeado](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/) laid out the factors that determine how destructive an earthquake actually is, and magnitude is only one of them:
+
+1. **Depth of the event**
+2. **Distance from the epicenter**
+3. **Soil type** — soft sediment amplifies shaking; rock doesn't
+4. **Vulnerability of the building**
+
+Look at that list for a second. The first three are geography. You inherit them. You cannot negotiate with them.
+
+The fourth one is a decision somebody made.
+
+---
+
+## Armenia
+
+In 1999, Armenia was destroyed. Then it was rebuilt — under seismic code.
+
+In 2026 it took an earthquake with 150 times the released energy and nobody died there. Buildings were damaged. Ninety percent of them were still declared habitable.
+
+I've read that fact maybe fifteen times now and it still lands the same way. There is a city in this country that already paid this bill, in full, over twenty-five years, and on the day it mattered the bill had been paid.
+
+Meanwhile Pereira, Cali and Manizales — cities with far more building stock predating that code, or built without applying it — took the worst of it. Sixty-six buildings in total collapse in Pereira alone.
+
+---
+
+## What NSR-10 actually promises
+
+Colombia's seismic-resistant building standard has a lineage. The first code came in **1984**, after the Popayán earthquake. It was updated in **1998**. The current version, **NSR-10**, has been in force since 2010.
+
+Here's the part most people get wrong, and I got wrong too until I read up on it: **NSR-10 does not promise your building will be fine.** It promises it will not collapse suddenly, so the people inside get out.
+
+A building can be damaged, cracked, evacuated and ultimately condemned, and still have done exactly what the code asked of it. "The building is wrecked" and "the code failed" are not the same statement. Very often they're opposites.
+
+The standard is strictest where it matters most — buildings with high occupancy or that the city depends on: hospitals, schools, universities, fire stations.
+
+Which is why the hospital numbers from Cali are the ones that should worry us. The **Hospital Universitario del Valle partially collapsed**. Seven large health institutions in the city were evacuated for structural failures. Nationally, 241 healthcare centers and 2,612 educational institutions were affected. Those are precisely the buildings the code treats as essential.
+
+---
+
+## The code exists. Applying it is the problem.
+
+Semana ran the finding as a headline: [most construction in Colombia isn't designed to NSR-10](https://www.semana.com/nacion/pereira/articulo/claves-de-la-destruccion-sismica-en-colombia-la-mayoria-de-las-construcciones-no-se-disenan-con-la-nsr-10/202618/).
+
+Chequeado adds the technical detail: a lot of Colombian structures use relatively thin concrete walls without adequate reinforcement against intense seismic forces.
+
+So we have a standard, written down, mandatory, twenty-five years of institutional learning behind it — and a building stock that largely predates or ignores it.
+
+I want to be careful about what I'm not saying. I'm not saying which buildings in Pereira were badly built. There's no public engineering assessment building by building; the city census only started on August 12. I'm not naming builders or curadurías. That's a matter for investigations that haven't happened yet.
+
+What I'm saying is what the engineers quoted in the national press are saying: the norm exists, it works where it's applied, and Armenia is the proof.
+
+---
+
+## The analogy I keep almost making
+
+I've written and deleted this paragraph four times, so let me just put it here with the warning attached.
+
+There is an obvious parallel between this and software. The standard existed. The documentation existed. What was missing was application and verification. Nobody checks whether the building complies until the ground moves, the same way nobody checks whether the backup restores until the disk dies. Armenia is what paying down technical debt looks like: expensive, slow, invisible for twenty-five years, and then decisive in ninety seconds.
+
+That's an imperfect analogy and I'm only going to use it once. The people who died aren't a metaphor for a production incident. But if you build things for a living and the comparison makes the stakes of "we'll fix it later" feel more real, then it earned its place.
+
+---
+
+## And the nonsense
+
+Within hours there were explanations circulating that weren't explanations. [Chequeado](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/) went through them:
+
+- **HAARP caused it.** No. HAARP studies the ionosphere. It has nothing to do with tectonics.
+- **Fracking caused it.** No. Colombia has no commercial fracking operations. The event was tectonic, not induced.
+- **The Puracé volcano triggered it.** Denied by the geological authorities; the volcano's activity was unaffected.
+- **It's connected to the Venezuela earthquake.** The SGC: different tectonic dynamics.
+
+And the one that keeps coming back in the form of chain messages predicting the next big aftershock — the SGC has been unambiguous. There is no scientifically proven method to predict when and where an earthquake will occur.
+
+I understand the impulse. A random catastrophe is harder to live with than a caused one. But a fake cause doesn't protect anybody, and the energy spent arguing about HAARP is energy not spent asking whether the school your kid attends was built to code.
+
+---
+
+## Resources
+
+- [Servicio Geológico Colombiano — official update on the earthquake](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx)
+- [Semana — most construction in Colombia isn't designed to NSR-10](https://www.semana.com/nacion/pereira/articulo/claves-de-la-destruccion-sismica-en-colombia-la-mayoria-de-las-construcciones-no-se-disenan-con-la-nsr-10/202618/)
+- [El Tiempo — seismic-resistant standards would have prevented worse damage in Armenia](https://www.eltiempo.com/amp/vida/ciencia/uso-de-normas-sismorresistentes-habria-evitado-mayores-desastres-en-armenia-3577445)
+- [Metrocuadrado — how safe are today's buildings](https://www.metrocuadrado.com/noticias/actualidad/terremoto-2026-en-colombia-que-tan-seguros-son-los-edificios-actuales-7030)
+- [Chequeado — twelve questions to understand what happened](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/)
+
+---
+
+We can't predict earthquakes. That part is settled science and it isn't going to change.
+
+We can decide what we build, and how, and whether anyone checks. Armenia decided in 1999, and in 2026 it collected.
+
+Let's keep building. Carefully.

--- a/src/content/blog/en/2026-08-24_why-twenty-apps-appeared-in-one-week.md
+++ b/src/content/blog/en/2026-08-24_why-twenty-apps-appeared-in-one-week.md
@@ -1,0 +1,123 @@
+---
+title: 'Why Twenty Apps Appeared in One Week'
+description: 'Days after the earthquake there were more than twenty citizen-built aid apps. The problem was never too many tools. It was the absence of bridges between them.'
+pubDate: '2026-08-24'
+tags: ['tech', 'civic-tech', 'colombia', 'personal']
+keywords: ['civic tech disaster response', 'aid apps Colombia earthquake', 'why so many emergency apps', 'data freshness emergency information', 'aggregating disaster data', 'WhatsApp coordination emergency', 'open data earthquake response']
+series: 'colombia-earthquake-2026'
+seriesOrder: 3
+draft: true
+---
+
+The first night, the information problem looked like this.
+
+A WhatsApp group with 400 people. Someone posts that a collection center on Avenida 30 de Agosto needs water. Forty people forward it. Two hours later that center is full and has stopped receiving anything, but the message is now in nine other groups and it will keep circulating for two more days. Somewhere in the same feed there's a voice note claiming a bridge is about to fail. Nobody knows who recorded it. Everybody forwards it.
+
+Meanwhile a woman is trying to find out whether the shelter closest to her mother is still taking people, and the most recent thing she can find is a screenshot of a list that has no date on it.
+
+That's not a failure of goodwill. There was no shortage of goodwill. It's a failure of infrastructure, and the infrastructure that failed wasn't only digital.
+
+---
+
+## The number that reframes everything
+
+According to MinTIC, **more than 3,400 mobile base stations went out of service**. Across seven departments, 46.1% of the stations they reviewed were down.
+
+Almost half the cell network in the affected region, gone, at the exact moment several million people needed to coordinate.
+
+The ministry's response is worth reading as engineering: it temporarily opened radio spectrum, made interconnection between operators mandatory — so your call could exit through whichever network was still standing, regardless of who you paid — and made emergency-line calls free for users with no balance. The ANE and MinTIC also started evaluating a band for direct-to-device satellite connectivity, so compatible phones could talk to a satellite without any terrestrial network at all. [Starlink offered free service until September 12](https://www.semana.com/tecnologia/articulo/starlink-anuncia-internet-satelital-gratis-a-colombia-tras-el-devastador-terremoto-asi-puede-recibirlo/202612/) and shipped hardware to response agencies.
+
+So when I say WhatsApp and spreadsheets don't scale in an emergency, I want to be precise about what I mean. It isn't that people were using the wrong tool. It's that for the first days, in a lot of the city, there *was* no tool. Information moved by radio, by paper taped to a wall, and by someone walking over to tell you.
+
+Everything built in that first week had to survive that.
+
+---
+
+## "Isn't this just another app?"
+
+This is the criticism, and it's fair enough that it deserves a real answer instead of a defensive one.
+
+More than twenty aid tools now exist for this emergency. Damage maps. Collection-center dashboards. Shelter directories. Missing-person matching. A lost-pet classifieds board. A community rental board. A municipal portal. Several of them overlap. Some were built by people who didn't know the others existed.
+
+The skeptical read is: this is ego. Everybody wanted to build their own thing instead of contributing to somebody else's, and the result is fragmentation dressed up as solidarity.
+
+I've thought about it honestly and I don't think that's what happened, though I'll admit there's a version of the story where it is.
+
+Here's what I actually think fragmentation means.
+
+Fragmentation is not *many tools*. Fragmentation is **many tools that can't read each other**.
+
+Consider what these things actually do:
+
+- SismoVision takes photos of cracks in walls and gives preliminary structural guidance.
+- Alluda tracks which collection centers are short on what, by city.
+- Encontrados.co lets a rescue worker photograph someone in their care and match them against missing-person reports.
+- SOS Pereira is the mayor's office running a census of affected businesses.
+
+Those are four different data models, four different users, four different update cycles, and four different failure modes. A crack-reporting tool is not a supply-chain tool. A municipal census is not person-to-person aid. Asking one app to do all of it produces something that does none of it well and takes three months to build — and we didn't have three months.
+
+Specialization was the correct response. What was missing wasn't consolidation. It was **bridges**.
+
+---
+
+## Freshness is the whole product
+
+If I had to name the single design decision that separates a useful emergency tool from a harmful one, it's this: does it tell you *when* the information was last true?
+
+A collection center's needs change in four hours. A shelter fills up. A hospital reopens. A road clears. In that environment, a polished list with no timestamp is worse than an ugly one with a timestamp, because the polished one is more convincing.
+
+Some of the tools here got this right immediately. [Unidos por Pereira](https://unidosporpereira.com/) shows the last-update time on each section. [Pereira Ayuda](https://pereiraayuda.com/) dates its directory of shelters, donation points and open hospitals in Pereira and Dosquebradas.
+
+That's not a small nicety. In a week where the official death toll was published four different ways on the same afternoon by four different entities — all of them honest, all of them cutting off at different hours — the timestamp *is* the trust mechanism.
+
+---
+
+## The aggregator that doesn't invent anything
+
+If you want proof that the network effect works without anybody having to die, look at [AquíAyuda](https://www.aquiayuda.com/).
+
+It centralizes earthquake aid information for the whole country: collection centers by municipality with what they need and what they already have, person-to-person help, everything sortable by proximity. And it does that by **aggregating other people's sources** — Ayudas Pereira, Corag, Pereira Responde, Pereira Unida — without inventing data of its own.
+
+That's the shape of the answer. Not one app to rule them all. A specialized layer that reads the others honestly and adds the thing none of them could do alone: a national view.
+
+It only works if the pieces underneath are readable. Which is why, of everything on this list, the two entries I find most encouraging are boring ones: [Pereira Responde](https://pereiraresponde.co/) publishes a documented public API, and Corag publishes an unauthenticated public API plus a remote MCP server. Not because APIs are exciting, but because an app with an API can be built on. An app without one is a dead end with a nice interface.
+
+---
+
+## The map of the network
+
+A few days ago the people behind several of these tools sat down together. Not to merge — to stop stepping on each other. That conversation is the reason [corag.app/ecosystem](https://corag.app/ecosystem/) exists, and it's the thing I've been putting most of my own hours into.
+
+It's a directory. Six categories: direct aid, damage reports, collection and logistics, pets, missing persons, and the municipal channel. Each entry describes what the tool says about itself, links to it, and notes whether we could confirm a public API. Inclusion is by form, reviewed by a person.
+
+Two things about it that I insisted on, and that I'd insist on again:
+
+**Listing is not endorsement.** The page says so explicitly. In an emergency where [the police have been warning about fake donation campaigns and people impersonating relief organizations](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/), the last thing anyone needs is a self-appointed trust badge. Describing a tool is not vouching for it, and pretending otherwise would make the directory part of the problem.
+
+**"No API confirmed" means we couldn't confirm one, not that there isn't one.** Most of these teams are exhausted and shipping. Absence of documentation is not absence of capability, and writing it the other way would be a cheap shot at people doing the same work I'm doing.
+
+The line at the top of the page is the one I'd keep if I had to throw out everything else: **No competimos. Nos alimentamos.** We don't compete. We feed each other.
+
+---
+
+## One more thing, and then I'll leave it
+
+Something worth noticing without making it the point of the article: while the civic side was busy figuring out how to interoperate, the national response went through a public debate about the opposite — Colombia [initially restricted international rescue teams](https://es.wikipedia.org/wiki/Terremoto_de_Colombia_de_2026), from Mexico, China, El Salvador and UN OCHA, on the argument that domestic capability was sufficient. Ecuador's 47-person team was accepted; Mexican brigades came independently.
+
+I don't have standing to judge that decision and I'm not going to try. I just find it hard to ignore that "should we let others help with this" was the live question at both ends of the response, and that the two ends answered it differently.
+
+---
+
+## Resources
+
+- [corag.app/ecosystem — the directory of aid apps](https://corag.app/ecosystem/)
+- [AquíAyuda — national aggregator of collection centers](https://www.aquiayuda.com/)
+- [Pereira Responde — damage map with public API](https://pereiraresponde.co/)
+- [DPL News — telcos, government and platforms activate emergency measures](https://dplnews.com/terremoto-en-colombia-activan-medidas-emergencia/)
+- [El País — nearly half of mobile antennas out of service](https://www.elpais.com.co/colombia/terremoto-en-colombia-casi-la-mitad-de-las-antenas-moviles-estan-fuera-de-servicio-estos-son-los-departamentos-mas-afectados-1143.html)
+
+---
+
+Twenty tools is not the problem. Twenty tools that can't read each other is the problem, and it's a solvable one — it's the only part of this whole catastrophe that's fully in our hands.
+
+Let's keep building.

--- a/src/content/blog/en/2026-08-27_the-map-of-the-network.md
+++ b/src/content/blog/en/2026-08-27_the-map-of-the-network.md
@@ -1,0 +1,149 @@
+---
+title: 'The Map of the Network'
+description: 'A tour of the twenty citizen-built tools responding to the Colombia earthquake, category by category. A description of what exists, not a ranking.'
+pubDate: '2026-08-27'
+tags: ['tech', 'civic-tech', 'colombia', 'web-development']
+keywords: ['aid apps directory Colombia earthquake', 'Pereira Responde API', 'Gravitas map Colombia', 'Encontrados.co missing persons', 'AquíAyuda collection centers', 'civic tech tools disaster', 'open source emergency platforms']
+series: 'colombia-earthquake-2026'
+seriesOrder: 4
+draft: true
+---
+
+Before anything else, the framing, because it changes how you should read every paragraph below.
+
+**This is a description, not a ranking.** Every summary here comes from what each tool says about itself on its own public site. I have not audited anybody's code, uptime, data quality or governance. Nobody is being certified. Nobody is being recommended over anybody else.
+
+**Listing is not endorsement.** [The directory this article is based on](https://corag.app/ecosystem/) says so on the page itself, and I want it repeated here, because the police have been [warning about fake donation campaigns and people impersonating relief organizations](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/) since the first week. A self-appointed trust badge would make this worse, not better.
+
+**"No public API confirmed" means exactly that.** It means I couldn't find documentation. Most of these teams are running on no sleep. Absence of docs is not absence of capability.
+
+**No personal data appears here.** Some of these tools handle missing-person reports. I describe the tool. I never describe a case.
+
+With that out of the way.
+
+---
+
+## Direct aid and matching
+
+Tools where a person publishes a need or an offer and the system tries to connect them.
+
+**[Corag Ayuda Directa](https://ayuda.corag.app)** — live map of requests and available people. You publish a need or an offer with consented contact details, and deliveries get tracked with public evidence. It documents an unauthenticated public API and a remote MCP server. This is the one I've been contributing to, which is why I'm going to spend the next article picking apart its technical decisions rather than praising them here.
+
+**[Pereira Unida](https://pereiraunida.com/)** — citizen aid coordination for Pereira and Dosquebradas: food, tools, medicine, volunteering, family networks, collection points.
+
+**[SOS Terremoto](https://conectando-ayudas-colombia.com/)** — a shared board for posting and picking up aid requests.
+
+**[Help Them Directly](https://helpthemdirectly.org/en/)** — a voluntary directory connecting donors with families raising funds for themselves. Its main campaign is the 2026 Venezuela earthquake, with a Colombia form alongside it. Important detail, stated by the site itself: **it does not handle money.** Families run their own channels.
+
+---
+
+## Damage and reports
+
+The largest category, which makes sense — after an earthquake, the first question everybody has is *is this building safe*.
+
+**[Pereira Responde](https://pereiraresponde.co/)** — a citizen map of infrastructure damage in Pereira: buildings, roads, support points. Up to three photos per report, plus shortcuts to nearby collection and shelter points. It publishes a **documented public API** at `/api/docs`, which puts it in a very small club.
+
+**[SismoVision](https://sismovision.com/)** — citizen reports of structural damage, specifically cracks, with preliminary guidance. The site is explicit that this does not replace a professional inspection, and that framing matters: the gap between "a tool told me my wall is probably fine" and "an engineer certified my building" is where people get hurt.
+
+**[Mapa del terremoto](https://www.mapadelterremoto.com/)** — an open map of damage from the August 10 earthquake: damage points, shelters and collection sites across several cities.
+
+**[Reporte CO](https://co.crafter.run/)** — an open, privacy-by-design platform mapping damage, trapped or injured people, shelters and service outages.
+
+**[Terremoto Colombia](https://terremotocolombia.co/)** — reports, damage map, and links out to official sources. It describes itself as a free, open-source citizen platform for connecting reports, resources and response teams, and as an independent, non-partisan initiative.
+
+**[Gravitas](https://mapa.gravitasworld.com/)** — real-time citizen mapping of buildings, collection centers and logistics. More on this one below.
+
+---
+
+## Collection and logistics
+
+Where the physical stuff is, what it needs, and how to move it.
+
+**[AquíAyuda](https://www.aquiayuda.com/)** — a national hub: collection centers by municipality showing what's short and what's covered, person-to-person help, sortable by proximity. It **aggregates other sources** (Ayudas Pereira, Corag, Pereira Responde, Pereira Unida) without inventing data.
+
+**[Acopio / Ayudas Pereira](https://alluda.online/)** — collection centers by city, with visibility into shortages and surpluses, plus registration for volunteers and transporters.
+
+**[Unidos por Pereira](https://unidosporpereira.com/)** — shelters, collection, meals, aid and pets, organized by theme, each with a last-updated time.
+
+**[Pereira Ayuda](https://pereiraayuda.com/)** — a dated directory of shelters, donation points and open hospitals in Pereira and Dosquebradas.
+
+**[ayuda.red](https://ayuda.red/)** — map of aid infrastructure plus a missing-persons registry, donation channels and official guides.
+
+**[Mapa de Ayuda — Gogó](https://soygogo.com/pereira-ayuda)** — aid points across Pereira.
+
+**[PereiraVive](https://pereiravive.com/)** — and this one deserves more attention than it's getting.
+
+It's a free community rental board for Pereira and nearby municipalities. You can search for housing, publish a listing, photograph a "se arrienda" sign you spotted on the street and post it — and **report price gouging**. No account required.
+
+Think about what that last feature means. Somewhere between forty thousand and one hundred forty thousand people in this city suddenly need somewhere to live, all in the same week. That is the textbook setup for rents doubling overnight. Somebody looked at that and built a way for neighbors to flag it publicly. It's the most quietly furious piece of software on this whole list and it took me three passes through the directory to notice it.
+
+The site is clear that it's a community board, not a real estate agency: verify the property in person, don't prepay.
+
+---
+
+## Pets
+
+**[Encuentra tu mascota](https://encuentratumascota.co/anuncios/se-busca)** — "missing" classifieds to reunite pets with their families.
+
+I've seen people online treat this category as frivolous. It isn't. Fourteen animals were pulled out of the rubble in Pereira by official rescue crews. For a family that lost their house, the dog is not a footnote.
+
+---
+
+## Missing persons
+
+The most delicate category by a long distance, and the one where design decisions have the highest cost.
+
+**[Encontrados.co](https://encontrados.co/)** — built for rescue workers. You photograph someone who is in your care, the system matches it against missing-person reports, and **the photo is deleted after the match**. Families can also file reports. It was built with volunteers from Ni500 / Torrenegra.
+
+That deletion is the entire design. The most valuable data in this system is also the data that most needs to not exist a minute longer than necessary — photographs of injured, disoriented or unconscious people, taken without their consent because consent wasn't possible. Building the delete step in from the start, in a week, under this pressure, is the single best engineering decision I've seen come out of this emergency.
+
+**[SOS Pereira 2026](https://sospereira.com/)** — the mayor's office citizen portal: missing-person reports, building damage reporting, a census of affected businesses, public listings, and operator access.
+
+This one is the city government's. Not Corag's, not a volunteer project. I'm saying that plainly because directories blur origins, and confusing a municipal channel with a citizen tool does a disservice to both.
+
+---
+
+## The one with the best documented method
+
+Of everything here, [Gravitas](https://mapa.gravitasworld.com/) is the case I'd point a working engineer at, partly because [El Colombiano documented it](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) so I'm not relying on my own read.
+
+Juan Camilo Garzón is a designer and anthropologist from Risaralda. His studio, Senza Create, had spent four years working on rural tourism. After the earthquake they rebuilt the platform for emergency use in **42 hours**.
+
+What it pulls together: citizen reports, satellite and georeferenced data from Copernicus, social media, official WhatsApp groups, and government and municipal reports. At the time of that article it had taken in roughly 250 citizen reports and 850 internal ones.
+
+The part worth stealing is how they decide what's true. Garzón's own words:
+
+> *"Si cinco personas reportan el mismo centro de acopio, eso nos ayuda a determinar que la información es verídica, más que un solo reporte que puede parecer inusual o no tener respaldo."*
+> ("If five people report the same collection center, that helps us determine the information is truthful, more than a single report that might look unusual or lack support.")
+
+Corroboration threshold plus AI plus an administrator reviewing before anything hits the map. Not "the AI decides." AI narrowing the field, a human closing it. Anyone who has built a citizen-reporting system eventually reinvents some version of this, usually after getting burned. They got there in under two days.
+
+---
+
+## What's missing from this map
+
+An honest directory should say what it can't see.
+
+I don't know which of these tools will still be running in three months. I don't know their data-retention policies beyond what they publish. I don't know how many of the collection-center entries are stale right now, in any of them, including the ones I work on. Nobody has audited the overlap to see how many reports are duplicated across four maps because the same neighbor filed in four places.
+
+And I don't know — nobody knows — whether any of this changed an outcome for a single person. I'd like to believe it did. I can't demonstrate it, and this is not a series where I get to claim things I can't demonstrate.
+
+If you run one of these and I've described it wrong, [the directory has a form](https://corag.app/ecosystem/), and a person reads every submission.
+
+---
+
+## Resources
+
+- [corag.app/ecosystem — the living directory](https://corag.app/ecosystem/)
+- [El Colombiano — the AI platform organizing aid, volunteers and resources](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222)
+- [Corag developer docs](https://corag.app/developers)
+- [Pereira Responde API docs](https://pereiraresponde.co/api/docs)
+- [National Police recommendations on avoiding donation scams](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/)
+
+---
+
+Twenty tools, six categories, one shared assumption: that somebody else's piece is worth reading instead of rebuilding.
+
+That assumption is younger than the emergency. Let's see if it outlives it.
+
+Let's keep building.

--- a/src/content/blog/en/2026-08-31_building-software-in-an-emergency.md
+++ b/src/content/blog/en/2026-08-31_building-software-in-an-emergency.md
@@ -1,0 +1,143 @@
+---
+title: 'Building Software in an Emergency'
+description: 'Nine things I learned shipping aid software after the Colombia earthquake: expiring data, PII, an unauthenticated public API, and what I would do differently.'
+pubDate: '2026-08-31'
+tags: ['tech', 'civic-tech', 'ai-agents', 'mcp', 'web-development']
+keywords: ['building software during a disaster', 'unauthenticated public API tradeoffs', 'idempotency source externalId', 'MCP server emergency response', 'PII missing persons privacy', 'offline first emergency app', 'data freshness timestamps API']
+series: 'colombia-earthquake-2026'
+seriesOrder: 5
+draft: true
+---
+
+This is the article I've rewritten the most, because the honest version keeps being less flattering than the first draft.
+
+The easy version goes: developers responded fast, AI let us build whole applications in hours, isn't that remarkable. All of that is true and I've said some of it already. But if the only thing I take away from this is that we were fast, I've learned nothing worth writing down.
+
+So here are nine things, in the order I actually ran into them, including the ones I'm still not comfortable with.
+
+---
+
+## 1. Data expires, and pretending otherwise is the failure mode
+
+Everything operational in this emergency had a shelf life measured in hours. A collection center stops receiving. A shelter fills. A hospital reopens. A road clears. A building that was safe yesterday got a 4.8 aftershock overnight.
+
+The instinct when you're shipping fast is to render the data cleanly and move on. The correct move is uglier: **show the timestamp, always, even when it embarrasses you.** "Updated 6 hours ago" is more useful than a beautiful card that implies freshness it doesn't have.
+
+[Unidos por Pereira](https://unidosporpereira.com/) and [Pereira Ayuda](https://pereiraayuda.com/) got this right from day one. I noticed it before I copied it, which is its own small lesson.
+
+The corollary is harder: if you can't refresh a dataset, say so, or take it down. A stale directory that looks live sends somebody across a city, in a week with no fuel and restricted vehicle circulation, to a door that's closed.
+
+---
+
+## 2. Ship fast versus don't cause harm
+
+This is the real tension and it doesn't resolve cleanly.
+
+The list of things a developer should not do in an emergency turned out to be much more specific than I expected:
+
+- **Don't scrape personal data.** Missing-person listings are public in a specific context for a specific purpose. Copying them into your own database because "it'll help matching" creates a permanent record nobody consented to.
+- **Don't publish private phone numbers**, even when someone posted theirs in a WhatsApp group. A group of 400 is not the public internet.
+- **Don't promise what you can't sustain.** If your app implies somebody is going to show up, somebody has to actually show up.
+- **Don't invent trust rankings.** No "verified NGOs" list, no badges, no star ratings on relief organizations. You don't have the standing and the police are already dealing with [people impersonating relief organizations and government officials](https://www.elcolombiano.com/colombia/terremoto-alerta-por-estafadores-policia-suplantacion-director-sanidad-damnificados-EG39953869).
+- **Don't add a CTA to a channel you haven't checked today.**
+
+The best counterexample in this whole ecosystem is [Encontrados.co](https://encontrados.co/), which I keep coming back to. Rescue workers photograph someone in their care, the system matches against missing-person reports, and **the photo is deleted after the match**. The most valuable data in the system is also the data that most needs to stop existing. They built the delete step in from the start, in a week, under pressure. That's the bar.
+
+---
+
+## 3. The unauthenticated public API — the decision I'm least sure about
+
+Corag documented a **public API with no authentication** during the emergency. Anyone can read the needs base and anyone can write to it. The reasoning was straightforward: friction is the enemy when other teams are trying to integrate at 2 a.m., and an API key process nobody staffs is the same as no API at all.
+
+I think it was the right call for the first weeks. I also think it's the decision I'd defend least well in a calm room, and I want to write down the actual trade-off instead of the marketing version.
+
+**What you get:** a base anyone can actually build on. Bots, dashboards, other PWAs and aggregators can read and write without asking permission or waiting on anybody. That's how you get [AquíAyuda](https://www.aquiayuda.com/) pulling from four sources.
+
+**What you're exposed to:** spam, data poisoning, and someone flooding the map with fake needs to make a specific neighborhood look neglected. Nothing structurally stops that. The mitigations are all downstream — corroboration, human review, rate limiting — and downstream mitigations are the ones you build after something goes wrong.
+
+**What I'd do differently, in cold blood:** keep reads open, put a cheap write path behind something. Not a key-request form — something automatic, like a per-source token you can self-issue and that gets revoked when a source misbehaves. Keep the zero-friction property, keep an audit trail. I didn't push for that in week one because week one was not the week for it, and I'm honestly not sure whether that was good judgment or a rationalization.
+
+---
+
+## 4. Idempotency is the difference between integrating and duplicating
+
+This one I *am* sure about, and it's the least glamorous item on the list.
+
+When five different clients can write the same need into the same base, you will get the same need five times unless the API refuses. Corag's public API is idempotent by design: a write carries a `source` and an `externalId`, and the same pair always resolves to the same record.
+
+That's it. That's the whole mechanism. And it's the difference between a shared base and a landfill.
+
+Without it, every integration makes the data worse. With it, an aggregator can re-sync every ten minutes without fear, and a team that goes offline for a day can replay everything they missed. If you're building anything that other people will write to, this is the first thing to get right and it costs almost nothing on day one. It costs a migration and a deduplication script on day thirty.
+
+---
+
+## 5. MCP, or: what happens when the client isn't a person
+
+Corag also exposes a remote MCP server, with tools along the lines of *list emergencies*, *publish a request*, *publish an offer*.
+
+If you haven't run into MCP yet: it's a protocol that lets an AI agent discover and call tools — roughly what an OpenAPI spec does for a developer, except the consumer is a model rather than a person writing integration code.
+
+Why this matters in an emergency is not the buzzword. It's that the set of people who could usefully query the needs base is much larger than the set of people who can write an HTTP client. A volunteer coordinator with an agent can ask "what's needed in Dosquebradas right now" and get a real answer from the live base, without anybody building them a dashboard. A neighborhood WhatsApp bot can publish a request without a developer wiring it up.
+
+I'll be honest that this is the piece where I'm most likely to be wrong about the impact. It's the newest and least proven thing on this list. But of everything we shipped, it's the one that made me think the shape of civic software is actually changing, and not just the speed of it.
+
+---
+
+## 6. Verification by corroboration, with a human closing it
+
+I covered [Gravitas](https://mapa.gravitasworld.com/) in the previous article, but the pattern belongs here too because it's the reusable part.
+
+Their rule, [as Juan Camilo Garzón described it to El Colombiano](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222): five people reporting the same collection center raises confidence far more than one report that looks unusual or unsupported. AI narrows, an administrator confirms, then it hits the map.
+
+The thing I want to underline is the direction of the loop. The model is not the decider. The model is the filter that makes human review tractable when 850 reports arrive and you have four people.
+
+Anybody who builds citizen reporting eventually arrives at some version of this, usually after publishing something false. They got there in 42 hours.
+
+---
+
+## 7. Design for a network that isn't there
+
+**More than 3,400 mobile base stations out of service.** 46.1% of stations reviewed across seven departments. That's from MinTIC, and it's the constraint that should have shaped everything and mostly didn't.
+
+If your app assumes a live connection, it doesn't work on the day it matters. What that implies, concretely: small payloads, aggressive caching, a usable read-only offline state, no blocking on third-party scripts, and — this is the part engineers resist — an answer to "how does this information reach someone with no signal at all?"
+
+The honest answer for most of these tools, including the ones I worked on, is *it doesn't*. It reaches someone with signal who then walks over and tells them. Which is fine, as long as you design knowing that's the last hop, and don't build as if the phone in the shelter is the endpoint.
+
+---
+
+## 8. Don't rebuild the collection-center map
+
+The strongest urge in the first 48 hours is to build the whole thing yourself, because integrating with someone else's half-finished project feels slower than starting clean.
+
+It isn't, and the arithmetic isn't close. Four teams building four collection-center maps produce four incomplete datasets and four sets of confused users. One team building a map and three teams reading its API produce one dataset that gets better every hour.
+
+The check I'd apply now, before writing a line: *does this already exist, and if so, does it have a way for me to read it?* If yes to both, build the thing on top. If yes to the first and no to the second, message the team — most of them will hand you a JSON endpoint if you ask, because they're not competing with you, they're exhausted.
+
+---
+
+## 9. What AI actually did, and what it didn't
+
+The thing everybody wants to talk about is that whole applications got built in hours. That happened. [Gravitas was rebuilt in 42 hours](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) by a studio that had been working on rural tourism. Twenty-plus tools exist that didn't exist three weeks ago. Some of that speed is unambiguously new, and I don't think anyone who lived through this week is going to be talked out of it.
+
+Here's what I keep next to that.
+
+Nobody can demonstrate that any of this saved a life. Not Corag, not any of the others. The missing-person count [dropped from 379 to 143](https://www.eltiempo.com/colombia/otras-ciudades/balance-oficial-de-la-ungrd-tras-terremoto-de-magnitud-7-4-en-colombia-273-fallecidos-3-824-heridos-y-377-desaparecidos-3578196) between August 13 and 15 — hundreds of people found — and I would love to claim a slice of that. I can't. The cross-referencing that produced it happened across hospitals, shelters, official registries, family networks and, somewhere in the mix, software. Untangling the contribution isn't possible and pretending otherwise would be exactly the behavior this series argues against.
+
+What AI clearly did was collapse the distance between *someone has an idea for a tool* and *the tool exists*. That's real and it's enormous. What it didn't do is decide what to build, decide what's true, or take responsibility for a wrong answer. Those three stayed entirely with us, and the week made me think they're going to keep staying with us longer than the current conversation assumes.
+
+---
+
+## Resources
+
+- [Corag developer documentation](https://corag.app/developers)
+- [Corag public OpenAPI spec](https://ayuda.corag.app/api/public/openapi.json)
+- [Corag MCP server](https://ayuda.corag.app/mcp)
+- [Pereira Responde API docs](https://pereiraresponde.co/api/docs)
+- [El Colombiano — how Gravitas verifies citizen reports](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222)
+- [MinTIC contingency plan for communications](https://laopinion.co/colombia/mintic-activa-plan-de-contingencia-para-garantizar-las-comunicaciones-tras-terremoto)
+
+---
+
+The uncomfortable summary is that the hard parts of this were never technical. Shipping was easy. Deciding what deserved to exist, what deserved to be deleted, and what we had no right to claim — that's where all the actual work was.
+
+Let's keep building. Carefully.

--- a/src/content/blog/en/2026-09-03_what-comes-next-after-the-earthquake.md
+++ b/src/content/blog/en/2026-09-03_what-comes-next-after-the-earthquake.md
@@ -1,0 +1,130 @@
+---
+title: 'What Comes Next'
+description: 'The rescue phase ends in weeks and reconstruction takes years. How to help now, how not to get scammed, and what actually survives once the cameras leave.'
+pubDate: '2026-09-03'
+tags: ['tech', 'personal', 'civic-tech', 'colombia']
+keywords: ['how to help Colombia earthquake victims', 'avoid donation scams Colombia', 'Colombia earthquake reconstruction cost', 'contribute to civic tech projects', 'long term disaster recovery', 'open data after emergency', 'Pereira reconstruction plan']
+series: 'colombia-earthquake-2026'
+seriesOrder: 6
+draft: true
+---
+
+The rescue phase of a disaster lasts about two weeks. Reconstruction lasts years, and almost nobody is watching by month three.
+
+That gap is the thing I want to talk about, because everything in this series was built during the two weeks.
+
+---
+
+## Where the reconstruction actually stands
+
+The government declared national disaster through **Decree 1171 of August 11, 2026**, followed by three days of national mourning and an announced economic emergency to fund rebuilding. Affected families were promised rent subsidies, suspension of utility bills, and a month's extension on tax filings.
+
+What it costs is still unsettled, and I want to show you the spread rather than pick a number:
+
+| Source | Estimate |
+|--------|----------|
+| Preliminary government estimates (via Portafolio) | $20 billion COP, ~1% of GDP |
+| La República | US$6.35 billion, 1% of GDP |
+| Oxford Economics | US$990M – US$1.98B, 0.2–0.4% of GDP |
+| USGS PAGER model | 34% probability of losses between US$1B and US$10B |
+
+Those numbers disagree by an order of magnitude, and the reason isn't that someone is lying. They measure different things. Some count direct physical damage; some count total economic loss including activity that won't happen; the USGS figures are automated probabilistic models published in the first hours, before any census existed. Anyone quoting one of them as *the* number is telling you more about their argument than about the damage.
+
+Locally: the governor of Risaralda, Juan Diego Patiño Ochoa, said he'd request around **$67 billion COP** from the royalties system, aimed mainly at housing and school infrastructure. Pereira's building census started August 12 and is the thing that will eventually turn all of this from estimate into fact.
+
+Nationally, 81,506 homes damaged and 14,493 destroyed, along with 298 roads, 44 bridges, 59 aqueducts, 241 health centers and 2,612 educational institutions.
+
+Those last two categories are why this isn't over in a year.
+
+---
+
+## If you're a neighbor
+
+Start from the category, not from a link somebody forwarded you. [The directory](https://corag.app/ecosystem/) is organized by what you actually need: shelters and collection points, damage reporting, missing persons, pets, housing, direct aid.
+
+Two specific things worth knowing about that most people haven't heard of:
+
+- **[PereiraVive](https://pereiravive.com/)** is a free community rental board, and it lets you **report price gouging**. If your rent just doubled, that's where it goes on the record.
+- **[Encuentra tu mascota](https://encuentratumascota.co/anuncios/se-busca)** exists and works. Fourteen animals were pulled from the rubble in Pereira by official crews alone.
+
+And check the date on anything operational before you act on it. A collection center's needs change in four hours.
+
+---
+
+## If you run an organization or a collection point
+
+Publish what you need, publish what you have too much of, and **publish the time you last updated it**.
+
+The surplus half matters more than people expect. A center drowning in used clothing while three blocks away another one has no water is the most common failure in this whole system, and it's entirely an information problem.
+
+If you can expose your data in any machine-readable form — even a JSON file you regenerate by hand twice a day — aggregators can pull from you instead of transcribing you. That's the difference between being on one map and being on six.
+
+---
+
+## If you're a developer
+
+**Read before you write.** Ask whether the thing exists, then whether you can read it. [Pereira Responde publishes a documented API](https://pereiraresponde.co/api/docs). [Corag's public API](https://corag.app/developers) is unauthenticated and idempotent, with a remote MCP server alongside it. If a tool you want to build on has no public docs, message the team — most will hand you an endpoint, because they're not competing with you.
+
+**Make writes idempotent from day one.** `source` + `externalId`. It costs nothing now and a migration later.
+
+**Timestamp everything.**
+
+**Don't touch personal data you don't need**, and delete the data you do need as soon as the job is done — the way [Encontrados.co](https://encontrados.co/) deletes the photo after the match.
+
+**Submit your tool to the directory** if it isn't there. There's a form, a person reads it, and inclusion isn't automatic. And if you find something in the listing described wrongly — including anything I wrote in this series — say so.
+
+**Don't silence the other pieces.** Nobody in this ecosystem wins by being the only one standing.
+
+---
+
+## Before you donate
+
+The police, through the DIJÍN, have been warning since the first week about a set of specific scams, and they're worth knowing by name:
+
+- **Impersonation of relief organizations**, social leaders and public officials, running fake collection campaigns. El Colombiano documented [someone posing as a health-services director](https://www.elcolombiano.com/colombia/terremoto-alerta-por-estafadores-policia-suplantacion-director-sanidad-damnificados-EG39953869).
+- **The trapped-relative call.** Someone phones claiming your family member is trapped or badly hurt, to panic you into sending money immediately.
+- **Fraudulent links** over WhatsApp, SMS and social media.
+
+The official recommendation is to validate through channels you can independently verify: the Red Cross, municipal governments, departmental governments, Civil Defense.
+
+I'll add one of my own, since this series has been arguing it for six articles: **prefer whoever shows you evidence of delivery over whoever shows you the most urgent story.** Urgency is easy to fake. A delivery record is harder.
+
+I'm deliberately not publishing account numbers or payment links anywhere in this series. If someone reads this in six months, any channel I listed could have changed hands.
+
+---
+
+## What survives when the cameras leave
+
+Here's the part I actually worry about.
+
+Twenty-plus tools got built in about two weeks. Several were built by two or three people, on evenings, on adrenaline, with no funding and no plan past the emergency. [Gravitas was adapted in 42 hours](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) by a studio whose actual business is rural tourism. At some point that studio has to go back to rural tourism.
+
+Reconstruction runs for years. Nothing on this list was built to run for years. That mismatch is not a criticism of anyone — building for the emergency was the correct thing to do — but it's a real problem arriving on a predictable schedule.
+
+I don't think the answer is that all twenty become sustainable products. Most won't, and shouldn't. Some are already redundant. Some solved a problem that only existed in week one.
+
+What I think survives is **the data and the interfaces to it**. A map is a rendering; the underlying dataset of damaged buildings, collection points, shelters and housing is the asset. If the datasets are open, documented and readable, then when a maintainer burns out or a domain lapses, somebody else can pick it up in an afternoon. If they're locked inside a SPA with no API, they die with the project and we start over next time.
+
+So the useful thing to do in month two, in my view, is unglamorous: get the data out from under the interfaces. Document the endpoints. Write down the schema. Hand the historical dataset to somebody institutional — a university, the municipality, whoever will still exist in 2029.
+
+That's the version of this where the next earthquake starts from something instead of nothing. And there will be a next one. Colombia has roughly 2,500 seismic events a month, we can't predict them, and the only variable we control is what we've built and what we've written down.
+
+---
+
+## Resources
+
+- [corag.app/ecosystem — the living directory](https://corag.app/ecosystem/)
+- [National Police — how to avoid scams during emergencies](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/)
+- [Portafolio — the initial reconstruction cost estimate](https://www.portafolio.co/economia/reconstruir-a-colombia-tras-el-terremoto-tendria-un-costo-inicial-de-20-billones-segun-estimaciones-preliminares-500175)
+- [LA FM — Risaralda seeks royalties funding for housing and schools](https://www.lafm.com.co/actualidad/risaralda-reconstruccion-viviendas-terremoto-colombia-2026-sesenta-y-siete-mil-millones-de-pesos-regalias-408019)
+- [Corag developer documentation](https://corag.app/developers)
+
+---
+
+In the first article I wrote that Pereira didn't go quiet for ninety seconds — it went quiet for three days, and what eventually filled that silence was people showing up with whatever they had.
+
+The showing up was never the hard part. Colombians are extremely good at the first two weeks. What we're historically worse at is month seven, when the story has moved on and the family in the shelter is still in the shelter.
+
+Whatever we're going to leave behind from this — the data, the code, the habit of reading each other's work instead of rebuilding it — has to be built now, while everyone still cares.
+
+Let's keep building.

--- a/src/content/blog/es/2026-08-17_the-day-pereira-went-quiet.md
+++ b/src/content/blog/es/2026-08-17_the-day-pereira-went-quiet.md
@@ -1,0 +1,140 @@
+---
+title: 'El día que Pereira se quedó en silencio'
+description: 'El 10 de agosto de 2026 un terremoto de magnitud 7,4 golpeó el occidente de Colombia. Pereira, mi ciudad, fue una de las más golpeadas. Qué pasó, con fuentes.'
+pubDate: '2026-08-17'
+tags: ['personal', 'colombia', 'tech']
+keywords: ['terremoto Colombia 2026', 'terremoto Pereira 10 de agosto', 'qué pasó en el terremoto de Colombia', 'cuántos muertos dejó el terremoto en Colombia', 'sismo San José del Palmar Chocó', 'edificios colapsados en Pereira', 'cuánto duró el terremoto en Colombia']
+series: 'colombia-earthquake-2026'
+seriesOrder: 1
+draft: true
+---
+
+Lunes 10 de agosto de 2026. 7:34 de la mañana.
+
+El [Servicio Geológico Colombiano](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx) dice que el movimiento duró entre noventa segundos y dos minutos. No he conocido a nadie en Pereira que lo recuerde en menos de cinco.
+
+Yo vivo acá. Y una semana después todavía no tengo una forma limpia de describir cómo está la ciudad, así que voy a prestarme la única frase que me ha sonado precisa: gran parte de Pereira se siente destruida, o irreconocible, y mucha gente necesita ayuda. Eso no es una estadística. Es lo que se siente al caminar por acá, y voy a mantener esas dos cosas separadas durante toda esta serie — lo que siento y lo que puedo demostrar.
+
+Este es el primero de seis artículos sobre el terremoto y sobre lo que hicieron unos cuantos cientos de desarrolladores en los días siguientes. Quiero empezar por la parte que no tiene nada que ver con software.
+
+---
+
+## Qué pasó, en concreto
+
+El epicentro estuvo cerca de **San José del Palmar**, en el Chocó, a unos 20 km del casco urbano. Magnitud **7,4**. Profundidad de **103 km** según el SGC — el USGS lo calcula un poco más hondo, en 110 km. En las primeras horas circularon 82 km y 96 km. Eran estimaciones tempranas que después se corrigieron, y vale la pena recordarlo, porque es el primer ejemplo pequeño de un patrón que marcó todo el resto de la semana.
+
+La profundidad explica por qué este se sintió distinto a todo.
+
+No fue una falla superficial rompiéndose debajo de una ciudad. Frente a la costa Pacífica, la placa de Nazca se hunde por debajo de la Sudamericana — subducción, el mismo proceso que levantó los Andes. Este sismo ocurrió *adentro* de esa placa que ya va descendiendo, a más de cien kilómetros de profundidad. El USGS lo clasifica como falla de rumbo dentro de la placa, no como una ruptura en el límite entre placas.
+
+Es decir: la energía vino de muy abajo y se repartió sobre un área enorme en vez de concentrarse en un valle. Más de **12.000 personas de 900 centros poblados** reportaron haberlo sentido, según el SGC. Se sintió en Panamá. Se sintió en Venezuela. Y siguió y siguió, porque — en palabras del SGC — cuando hay magnitudes tan altas, la energía liberada no alcanza a disiparse completamente por debajo de la superficie.
+
+Es el sismo de mayor magnitud registrado en Colombia en este siglo.
+
+Después empezaron las réplicas. Dieciocho al mediodía del primer día. [Más de 130 a las seis de la mañana del 12 de agosto](https://www.infobae.com/colombia/2026/08/12/tras-el-terremoto-de-74-en-colombia-ya-son-130-las-replicas-confirmo-el-servicio-geologico-colombiano/), entre 0,6 y 4,8, concentradas en San José del Palmar y Sipí. El 13 volvió a temblar fuerte en el Chocó de madrugada.
+
+Las réplicas son la razón por la que la gente dejó de dormir bajo techo. Y también son la razón por la que cualquier información sobre si un edificio era seguro tenía una vida útil que se medía en horas.
+
+---
+
+## Las cifras, y por qué se siguen moviendo
+
+Acá quiero ir con cuidado, porque es donde mucha escritura sobre desastres se tuerce sin que nadie se dé cuenta.
+
+Entre el 10 y el 15 de agosto las cifras oficiales cambiaron todos los días, y a veces varias veces al día. Distintas entidades — la UNGRD, Asocapitales, alcaldías, gobernaciones — publicaron consolidados diferentes en el mismo momento. No porque alguien mintiera. Porque cada una cortaba a una hora distinta, y durante los primeros días no había un consolidado nacional único.
+
+Así se ve:
+
+| Corte | Fallecidos | Heridos | Desaparecidos |
+|-------|-----------|---------|---------------|
+| 10 ago (preliminar, Asocapitales) | 132 | 570 | — |
+| 12 ago (UNGRD) | 239 | 3.755 | 287 |
+| 13 ago (UNGRD) | 281 | 3.971 | 379 |
+| **15 ago, 6:30 p. m. (UNGRD)** | **289** | **3.937** | **143** |
+
+Quince departamentos. Cuatrocientos cincuenta municipios.
+
+Mira la última columna. Los desaparecidos pasaron de 379 a 143 en dos días.
+
+Esa caída no es la corrección de un error de nadie. Son varios cientos de personas que aparecieron — que se reunieron con su familia, que estaban en un albergue, que fueron identificadas. Es, en el sentido más literal, el resultado de seres humanos cruzando listas. Voy a volver a eso más adelante en la serie, porque parte de ese cruce ocurrió en software que no existía la semana anterior.
+
+Por departamento, con corte al 13 de agosto: Valle del Cauca 125, **Risaralda 94**, Chocó 14, Caldas 6, Quindío 3, Antioquia 1. Según Asocapitales, las ciudades capitales concentraron cerca del 75 % de los fallecidos. Este fue un desastre urbano.
+
+---
+
+## Pereira
+
+[El Tiempo la llamó la ciudad más golpeada](https://www.eltiempo.com/justicia/investigacion/pereira-la-ciudad-mas-golpeada-por-el-terremoto-al-menos-67-victimas-mortales-3577462), y el conteo de edificios explica por qué.
+
+El reporte temprano de la Alcaldía: **66 edificaciones con colapso total, 26 con colapso parcial**, más cientos de viviendas afectadas. Reportes posteriores subieron la cifra por encima de 80. Doscientas cuarenta y tres personas rescatadas. Doscientas setenta y nueve trasladadas a clínicas y hospitales. Catorce animales sacados de los escombros.
+
+El edificio Invico, sobre la Avenida Circunvalar, es el que todo el mundo ha visto. Su piso doce simplemente no está. Tres personas quedaron atrapadas ahí y [no pudieron ser recuperadas](https://www.pulzo.com/nacion/terremoto-pereira-danos-edificio-invico-rescatados-balance-oficial-PP5272271), porque no quedó paso entre pisos.
+
+Unos 267 rescatistas trabajaban al mismo tiempo, entre personal local y equipos USAR enviados desde Bogotá, Envigado, Yopal y Medellín. Solo Bogotá mandó cien personas. Y al lado de ellos, miles de vecinos. En Los Álamos y en Lorena, más de doscientas personas se concentraron en dos puntos a escarbar.
+
+Se habilitaron albergues en el Parque El Vergel, el Parque El Oso, el Coliseo Mayor, el Parque Olaya, la Plaza de Ferias y el Estadio Mora Mora. [Dos llegaron al límite en cuestión de días](https://www.semana.com/nacion/pereira/articulo/terremoto-en-pereira-dos-albergues-ya-estan-al-limite-y-estos-son-los-puntos-disponibles/202651/).
+
+El alcalde Mauricio Salazar declaró calamidad pública y emergencia económica, impuso toque de queda de seis de la tarde a cinco de la mañana tras reportes de saqueos, y después prohibió por completo la circulación de vehículos particulares desde la medianoche del 12 hasta las ocho de la noche del 17. El censo de edificaciones arrancó el 12.
+
+La cifra que más se movió fue la de damnificados. Empezó en "2.000, y seguramente vamos a llegar a 4.000". Después llegó a **41.600 familias, alrededor de 140.000 personas afectadas**. No son números contradictorios — el primero era gente en albergues, el segundo es gente cuya vivienda quedó afectada. Pero si los ves citados uno al lado del otro sin esa distinción, parecen un desorden, y no lo son.
+
+---
+
+## Tres días sin nada
+
+Gran parte de la ciudad se quedó sin agua, sin energía y sin internet al mismo tiempo, y así estuvo unos tres días. Algunos sectores todavía no tienen, o lo tienen intermitente, mientras escribo esto.
+
+A nivel nacional, [Andesco reportó el 93 % del servicio eléctrico restablecido](https://www.lafm.com.co/economia/terremoto-colombia-reestablecimiento-servicio-electrico-terremoto-407808) en cuestión de días, y Pereira pasó del 75 % a cerca del 90 %. Algunos sectores siguieron sin luz a propósito, por seguridad, no por falta de capacidad. El agua volvió de forma progresiva mientras se inspeccionaban las redes de distribución dañadas. El gas siguió cortado en varias zonas mientras controlaban fugas.
+
+La caída de telecomunicaciones es la que no se me quita de la cabeza como ingeniero. Según el MinTIC, **más de 3.400 estaciones base móviles quedaron fuera de servicio** — el 46,1 % de las estaciones revisadas en siete departamentos. Casi la mitad de la red celular de la región afectada, abajo.
+
+El ministerio abrió espectro de forma temporal, volvió obligatoria la interconexión entre operadores para que una llamada pudiera salir por la red que estuviera viva, y liberó las llamadas a líneas de emergencia para usuarios sin saldo. [Starlink ofreció servicio gratuito hasta el 12 de septiembre](https://www.semana.com/tecnologia/articulo/starlink-anuncia-internet-satelital-gratis-a-colombia-tras-el-devastador-terremoto-asi-puede-recibirlo/202612/) y envió equipos para organismos de respuesta. Acá se instalaron antenas.
+
+Menciono todo esto ahora porque voy a dedicar los siguientes artículos a hablar de aplicaciones, y no quiero hacerlo de forma deshonesta. Durante los primeros días, buena parte de la ciudad no tenía cómo abrir una.
+
+---
+
+## Cada quien ayudó desde donde estaba parado
+
+Esta es la parte que no esperaba, y es la razón por la que estoy escribiendo.
+
+La colaboración que salió de esto ha sido impresionante. Los médicos hicieron medicina. Los restaurantes cocinaron. El que tenía camión movió cosas. El que tenía un cuarto libre lo ofreció. Estudiantes clasificando donaciones en bodegas durante días enteros. Rescatistas que siguieron mucho más allá del punto en que alguien lo habría llamado razonable — El Colombiano publicó una entrevista con uno de ellos bajo el titular *"Estoy donde me toque, lo más importante es ayudar"*, y La Patria publicó otra titulada *"Estamos cansados pero satisfechos de ayudar"*. Esas son sus palabras, no las mías.
+
+Cada quien aportó desde lo que sabe hacer.
+
+Yo no sé sacar a nadie de un edificio colapsado. Nunca he sido tan consciente de eso como en esta última semana. Lo que sé hacer es software.
+
+Así que eso fue lo que hicimos muchos. En cuestión de días había mapas de daños, tableros de centros de acopio, herramientas para cruzar reportes de personas desaparecidas, directorios de albergues, hasta un clasificado para mascotas perdidas. Algunas se construyeron en horas. Una de ellas, [Gravitas, se rehízo para la emergencia en 42 horas](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222), por un estudio de diseño que hasta esa semana trabajaba en turismo rural.
+
+Yo ayudé a construir la landing de [Corag](https://corag.app/), donde un equipo está trabajando en conectar a quien necesita algo con quien puede darlo. Y empecé a hacer lo que resultó ser mi aporte real: anotar quién más está allá afuera, para que las piezas se puedan encontrar entre sí. Esa lista vive en [corag.app/ecosystem](https://corag.app/ecosystem/).
+
+Ya son más de veinte herramientas. Hace unos días la gente detrás de varias de ellas se sentó a mirar cómo dejar de duplicarse. De esa conversación trata el resto de esta serie.
+
+---
+
+## Una nota sobre las cifras de esta serie
+
+Cada número de estos artículos lleva fuente nombrada y fecha de corte. Lo hago por una razón aburrida y por una importante.
+
+La aburrida es que estos números todavía se están moviendo. Cualquier cosa que escriba hoy va a estar desactualizada en algún margen el mes entrante, y un número sin fecha es un número que empieza a mentir en silencio a medida que envejece.
+
+La importante es que toda esta serie sostiene que la información confiable importa — que los timestamps y la evidencia son la diferencia entre que la ayuda llegue y que se evapore. No puedo defender eso en un artículo que juega sucio con sus propios datos.
+
+Entonces: nada de porcentajes inventados. Nada de "media ciudad quedó destruida". A mí me *parece* que media ciudad quedó destruida. Eso es una sensación, está en el tercer párrafo de este post, y está marcada como tal.
+
+---
+
+## Recursos
+
+- [Servicio Geológico Colombiano — actualización oficial sobre el sismo de San José del Palmar](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx)
+- [Chequeado — doce preguntas y respuestas para entender qué pasó](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/)
+- [El Tiempo — balance oficial de la UNGRD](https://www.eltiempo.com/colombia/otras-ciudades/balance-oficial-de-la-ungrd-tras-terremoto-de-magnitud-7-4-en-colombia-273-fallecidos-3-824-heridos-y-377-desaparecidos-3578196)
+- [corag.app/ecosystem — directorio de las apps de ayuda construidas tras el terremoto](https://corag.app/ecosystem/)
+
+---
+
+Pereira no se quedó en silencio noventa segundos. Se quedó en silencio tres días — sin luz, sin agua, sin señal, y con mucha gente parada en la calle porque volver a entrar se sentía como una apuesta.
+
+Lo que llenó ese silencio, con el tiempo, fue gente apareciendo con lo que tenía.
+
+A seguir construyendo.

--- a/src/content/blog/es/2026-08-20_one-hundred-three-kilometers-down.md
+++ b/src/content/blog/es/2026-08-20_one-hundred-three-kilometers-down.md
@@ -1,0 +1,141 @@
+---
+title: 'Ciento tres kilómetros abajo'
+description: 'El terremoto de 2026 liberó unas 150 veces más energía que el que arrasó Armenia en 1999, y mató a mucha menos gente. Por qué pasó eso, con fuentes.'
+pubDate: '2026-08-20'
+tags: ['tech', 'personal', 'colombia']
+keywords: ['por qué fue tan profundo el terremoto en Colombia', 'placa de Nazca subducción Colombia', 'qué es la norma NSR-10', 'comparación terremoto Armenia 1999 y 2026', 'sismo intraplaca explicado', 'por qué se caen los edificios en un terremoto', 'terremoto Colombia HAARP falso']
+series: 'colombia-earthquake-2026'
+seriesOrder: 2
+draft: true
+---
+
+Esta es la pregunta que no me deja tranquilo desde que las cifras empezaron a estabilizarse.
+
+El terremoto del 25 de enero de 1999 — el que acá simplemente llamamos *el del Eje Cafetero* — fue de magnitud 6,1. Dejó **1.185 muertos**, más de 8.500 heridos y cerca de 36.000 viviendas destruidas o inhabilitadas en 28 municipios. Armenia, la ciudad en el centro de todo, quedó arrasada.
+
+El terremoto del 10 de agosto de 2026 fue de magnitud 7,4. Como la escala de magnitud es logarítmica, esa diferencia es mucho mayor de lo que parece: el momento sísmico liberado fue unas **150 veces mayor** que en 1999.
+
+Y Armenia reportó **cero muertos**. El noventa por ciento de sus construcciones fue declarado habitable.
+
+Eso no es suerte. Me puse a buscar la explicación, y resulta que hay dos, y solo una es geología.
+
+---
+
+## Por qué este vino de tan abajo
+
+Frente a la costa Pacífica colombiana, la placa de Nazca se hunde por debajo de la Sudamericana. Eso es subducción — el choque en cámara lenta que levantó los Andes y que le da a este país unos 2.500 eventos sísmicos al mes.
+
+La mayoría de los terremotos que hacen daño ocurren cerca de la superficie, donde una falla se rompe a pocos kilómetros debajo de una ciudad y el movimiento se concentra, violento, en un área pequeña. Eso fue 1999.
+
+Este fue distinto. Ocurrió *adentro* de la propia placa de Nazca, a más de cien kilómetros de profundidad, mucho después de que esa placa ya se hubiera metido debajo del continente. El USGS lo lee como falla de rumbo dentro de la placa en descenso, no como una ruptura en el límite entre placas.
+
+La profundidad cambia todo el comportamiento de un sismo en superficie:
+
+- **Se reparte.** La energía liberada a 103 km llega a la superficie sobre una huella enorme en vez de concentrarse en un valle. Por eso [más de 12.000 personas en 900 centros poblados](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx) reportaron sentirlo, y por eso se registró en Panamá y en Venezuela.
+- **Dura.** Noventa segundos a dos minutos, contra los pocos segundos que suele dar un sismo superficial.
+- **No rompe la superficie.** Sin escarpe visible, sin tsunami.
+- **Es más débil por kilómetro cuadrado.** La misma energía dividida sobre un área mucho mayor significa menor intensidad pico en cualquier punto concreto.
+
+El SGC lo dijo sin rodeos cuando la gente preguntó por qué algo tan profundo se sintió tan lejos: cuando hay magnitudes tan altas, la energía liberada no alcanza a disiparse completamente por debajo de la superficie.
+
+La intensidad máxima registrada fue **VIII en la escala de Mercalli Modificada** — severa. El SGC reportó 7 en la escala EMS-98, que también corresponde a daño severo. La aceleración pico del suelo medida en Jamundí fue de 0,427 g.
+
+Entonces: un terremoto mucho más grande, repartido mucho más delgado. Esa es la explicación número uno, y es la que más se repite. Es cierta, y es incompleta.
+
+---
+
+## Las cuatro cosas que deciden si un edificio se cae
+
+[Chequeado](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/) enumeró los factores que determinan qué tan destructivo termina siendo un sismo, y la magnitud es apenas uno:
+
+1. **Profundidad del evento**
+2. **Distancia al epicentro**
+3. **Tipo de suelo** — el sedimento blando amplifica el movimiento; la roca no
+4. **Vulnerabilidad de la edificación**
+
+Mira esa lista un segundo. Los tres primeros son geografía. Los heredas. No se negocia con ellos.
+
+El cuarto es una decisión que alguien tomó.
+
+---
+
+## Armenia
+
+En 1999, Armenia quedó destruida. Después se reconstruyó — bajo norma sismorresistente.
+
+En 2026 recibió un sismo con 150 veces la energía liberada y allá no murió nadie. Hubo daños. El noventa por ciento de las construcciones quedó igual declarado habitable.
+
+Habré leído ese dato unas quince veces y me sigue cayendo igual. Hay una ciudad en este país que ya pagó esta cuenta, completa, a lo largo de veinticinco años, y el día que importó la cuenta estaba paga.
+
+Mientras tanto Pereira, Cali y Manizales — ciudades con muchísimo más inventario construido antes de esa norma, o construido sin aplicarla — se llevaron lo peor. Sesenta y seis edificaciones con colapso total solo en Pereira.
+
+---
+
+## Qué promete de verdad la NSR-10
+
+La norma sismorresistente colombiana tiene un linaje. El primer código llegó en **1984**, después del terremoto de Popayán. Se actualizó en **1998**. La versión vigente, la **NSR-10**, rige desde 2010.
+
+Acá está la parte que casi todo el mundo entiende mal, y que yo también entendía mal hasta que me puse a leer: **la NSR-10 no promete que tu edificio quede bien.** Promete que no colapse de golpe, para que la gente adentro alcance a salir.
+
+Un edificio puede quedar dañado, agrietado, evacuado y finalmente condenado, y aun así haber hecho exactamente lo que la norma le pidió. "El edificio quedó destruido" y "la norma falló" no son la misma frase. Muchas veces son lo contrario.
+
+La norma es más estricta donde más importa — edificaciones de alta ocupación o de las que depende la ciudad: hospitales, colegios, universidades, estaciones de bomberos.
+
+Por eso las cifras de hospitales en Cali son las que deberían preocuparnos. El **Hospital Universitario del Valle tuvo colapso parcial**. Siete grandes instituciones de salud de la ciudad fueron evacuadas por fallas estructurales. A nivel nacional se vieron afectados 241 centros de salud y 2.612 instituciones educativas. Son justamente las edificaciones que la norma trata como esenciales.
+
+---
+
+## La norma existe. El problema es aplicarla.
+
+Semana lo publicó como titular: [la mayoría de las construcciones en Colombia no se diseñan con la NSR-10](https://www.semana.com/nacion/pereira/articulo/claves-de-la-destruccion-sismica-en-colombia-la-mayoria-de-las-construcciones-no-se-disenan-con-la-nsr-10/202618/).
+
+Chequeado agrega el detalle técnico: muchas estructuras colombianas usan muros de hormigón relativamente delgados, sin refuerzo adecuado frente a fuerzas sísmicas intensas.
+
+Así que tenemos una norma, escrita, obligatoria, con veinticinco años de aprendizaje institucional detrás — y un parque construido que en buena parte es anterior a ella o la ignora.
+
+Quiero ser cuidadoso con lo que *no* estoy diciendo. No estoy diciendo cuáles edificios de Pereira estaban mal construidos. No hay peritaje público edificio por edificio; el censo de la ciudad apenas arrancó el 12 de agosto. No estoy señalando constructoras ni curadurías. Eso es materia de investigaciones que todavía no ocurren.
+
+Lo que estoy diciendo es lo que dicen los ingenieros citados por la prensa nacional: la norma existe, funciona donde se aplica, y Armenia es la prueba.
+
+---
+
+## La analogía que casi hago
+
+He escrito y borrado este párrafo cuatro veces, así que lo dejo acá con la advertencia puesta.
+
+Hay un paralelo evidente entre esto y el software. La norma existía. La documentación existía. Lo que faltó fue aplicación y verificación. Nadie revisa si el edificio cumple hasta que la tierra se mueve, igual que nadie revisa si el backup restaura hasta que el disco muere. Armenia es cómo se ve pagar deuda técnica: caro, lento, invisible durante veinticinco años, y después decisivo en noventa segundos.
+
+Es una analogía imperfecta y la voy a usar una sola vez. La gente que murió no es una metáfora de un incidente en producción. Pero si construyes cosas para vivir y la comparación te hace sentir más real el costo de "lo arreglamos después", entonces se ganó su lugar.
+
+---
+
+## Y las bobadas
+
+En cuestión de horas empezaron a circular explicaciones que no eran explicaciones. [Chequeado](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/) las revisó una por una:
+
+- **Lo causó HAARP.** No. HAARP estudia la ionósfera. No tiene nada que ver con tectónica.
+- **Lo causó el fracking.** No. Colombia no tiene operaciones comerciales de fracking. El evento fue tectónico, no inducido.
+- **Lo activó el volcán Puracé.** Negado por las autoridades geológicas; la actividad del volcán no se vio afectada.
+- **Está conectado con el terremoto de Venezuela.** El SGC: dinámicas tectónicas diferentes.
+
+Y la que vuelve una y otra vez en forma de cadenas prediciendo la próxima réplica grande — el SGC ha sido inequívoco. No existe un método científicamente comprobado que permita predecir cuándo y dónde ocurrirá un terremoto.
+
+Entiendo el impulso. Una catástrofe aleatoria es más difícil de vivir que una causada. Pero una causa falsa no protege a nadie, y la energía que se gasta discutiendo sobre HAARP es energía que no se gasta preguntando si el colegio al que va tu hijo se construyó bajo norma.
+
+---
+
+## Recursos
+
+- [Servicio Geológico Colombiano — actualización oficial sobre el sismo](https://www2.sgc.gov.co/Noticias/Paginas/SGC-actualiza-la-informacion-sobre-el-sismo-ocurrido-en-San-Jose-del-Palmar-Choco.aspx)
+- [Semana — la mayoría de las construcciones no se diseñan con la NSR-10](https://www.semana.com/nacion/pereira/articulo/claves-de-la-destruccion-sismica-en-colombia-la-mayoria-de-las-construcciones-no-se-disenan-con-la-nsr-10/202618/)
+- [El Tiempo — el uso de normas sismorresistentes habría evitado mayores desastres en Armenia](https://www.eltiempo.com/amp/vida/ciencia/uso-de-normas-sismorresistentes-habria-evitado-mayores-desastres-en-armenia-3577445)
+- [Metrocuadrado — qué tan seguros son los edificios actuales](https://www.metrocuadrado.com/noticias/actualidad/terremoto-2026-en-colombia-que-tan-seguros-son-los-edificios-actuales-7030)
+- [Chequeado — doce preguntas para entender qué pasó](https://chequeado.com/el-explicador/terremoto-en-colombia-10-preguntas-y-respuestas-para-entender-que-paso/)
+
+---
+
+No podemos predecir terremotos. Esa parte es ciencia resuelta y no va a cambiar.
+
+Sí podemos decidir qué construimos, cómo, y si alguien lo revisa. Armenia lo decidió en 1999, y en 2026 lo cobró.
+
+A seguir construyendo. Con cuidado.

--- a/src/content/blog/es/2026-08-24_why-twenty-apps-appeared-in-one-week.md
+++ b/src/content/blog/es/2026-08-24_why-twenty-apps-appeared-in-one-week.md
@@ -1,0 +1,123 @@
+---
+title: 'Por qué aparecieron veinte apps en una semana'
+description: 'Días después del terremoto había más de veinte apps ciudadanas de ayuda. El problema nunca fue tener muchas herramientas. Fue la ausencia de puentes.'
+pubDate: '2026-08-24'
+tags: ['tech', 'civic-tech', 'colombia', 'personal']
+keywords: ['apps de ayuda terremoto Colombia', 'tecnología cívica emergencias', 'por qué hay tantas apps de emergencia', 'información desactualizada en emergencias', 'centros de acopio Pereira', 'coordinación por WhatsApp en emergencias', 'datos abiertos terremoto']
+series: 'colombia-earthquake-2026'
+seriesOrder: 3
+draft: true
+---
+
+La primera noche, el problema de información se veía así.
+
+Un grupo de WhatsApp con 400 personas. Alguien publica que un centro de acopio en la Avenida 30 de Agosto necesita agua. Cuarenta personas lo reenvían. Dos horas después ese centro está lleno y dejó de recibir, pero el mensaje ya está en otros nueve grupos y va a seguir circulando dos días más. En el mismo hilo hay una nota de voz diciendo que un puente está a punto de fallar. Nadie sabe quién la grabó. Todo el mundo la reenvía.
+
+Mientras tanto una señora está tratando de averiguar si el albergue más cercano a su mamá todavía recibe gente, y lo más reciente que encuentra es la captura de pantalla de una lista que no tiene fecha.
+
+Eso no es una falla de buena voluntad. Buena voluntad sobraba. Es una falla de infraestructura, y la infraestructura que falló no era solo digital.
+
+---
+
+## El dato que reencuadra todo
+
+Según el MinTIC, **más de 3.400 estaciones base móviles quedaron fuera de servicio**. En siete departamentos, el 46,1 % de las estaciones revisadas estaba caído.
+
+Casi la mitad de la red celular de la región afectada, abajo, justo en el momento en que varios millones de personas necesitaban coordinarse.
+
+La respuesta del ministerio fue interesante desde el punto de vista de ingeniería: abrió espectro radioeléctrico de forma temporal, volvió obligatoria la interconexión entre operadores — para que tu llamada pudiera salir por la red que siguiera en pie, sin importar a quién le pagas — y liberó las llamadas a líneas de emergencia para usuarios sin saldo. La ANE y el MinTIC además empezaron a evaluar una banda para conectividad satelital *direct-to-device*, de modo que los celulares compatibles pudieran hablar con un satélite sin ninguna red terrestre de por medio. [Starlink ofreció servicio gratuito hasta el 12 de septiembre](https://www.semana.com/tecnologia/articulo/starlink-anuncia-internet-satelital-gratis-a-colombia-tras-el-devastador-terremoto-asi-puede-recibirlo/202612/) y envió equipos a los organismos de respuesta.
+
+Así que cuando digo que WhatsApp y las hojas de cálculo no escalan en una emergencia, quiero ser preciso. No es que la gente estuviera usando la herramienta equivocada. Es que durante los primeros días, en buena parte de la ciudad, *no había* herramienta. La información se movió por radio, por papel pegado en una pared, y porque alguien caminó hasta donde estabas a contarte.
+
+Todo lo que se construyó esa primera semana tuvo que sobrevivir a eso.
+
+---
+
+## "¿Esto no es otra app más?"
+
+Esta es la crítica, y es lo suficientemente razonable como para merecer una respuesta de verdad en vez de una defensiva.
+
+Hoy existen más de veinte herramientas de ayuda para esta emergencia. Mapas de daños. Tableros de centros de acopio. Directorios de albergues. Cruce de personas desaparecidas. Un clasificado de mascotas perdidas. Un tablero comunitario de arriendos. Un portal municipal. Varias se traslapan. Algunas las construyó gente que no sabía que las otras existían.
+
+La lectura escéptica es: esto es ego. Todo el mundo quiso construir lo suyo en vez de aportar a lo de otro, y el resultado es fragmentación disfrazada de solidaridad.
+
+Lo he pensado con honestidad y no creo que eso sea lo que pasó, aunque admito que existe una versión de la historia donde sí.
+
+Esto es lo que yo creo que significa fragmentación.
+
+Fragmentación no es *muchas herramientas*. Fragmentación es **muchas herramientas que no se pueden leer entre sí**.
+
+Piensa en lo que realmente hacen estas cosas:
+
+- SismoVision recibe fotos de grietas en muros y da orientación estructural preliminar.
+- Alluda lleva el control de qué le falta a cada centro de acopio, por ciudad.
+- Encontrados.co le permite a un rescatista fotografiar a alguien que está a su cuidado y cruzarlo contra reportes de desaparecidos.
+- SOS Pereira es la Alcaldía levantando un censo de empresarios afectados.
+
+Son cuatro modelos de datos distintos, cuatro usuarios distintos, cuatro ciclos de actualización distintos y cuatro modos de falla distintos. Una herramienta de reporte de grietas no es una herramienta de cadena de suministro. Un censo municipal no es ayuda persona a persona. Pedirle a una sola app que haga todo produce algo que no hace bien nada y que se demora tres meses en construir — y no teníamos tres meses.
+
+La especialización fue la respuesta correcta. Lo que faltaba no era consolidación. Eran **puentes**.
+
+---
+
+## La frescura del dato es el producto entero
+
+Si tuviera que nombrar la única decisión de diseño que separa una herramienta de emergencia útil de una dañina, sería esta: ¿te dice *cuándo* fue cierta la información por última vez?
+
+Las necesidades de un centro de acopio cambian en cuatro horas. Un albergue se llena. Un hospital reabre. Una vía se despeja. En ese contexto, una lista pulida sin fecha es peor que una fea con fecha, porque la pulida convence más.
+
+Algunas de estas herramientas lo entendieron de inmediato. [Unidos por Pereira](https://unidosporpereira.com/) muestra la hora de última actualización en cada sección. [Pereira Ayuda](https://pereiraayuda.com/) fecha su directorio de albergues, puntos de donación y hospitales abiertos en Pereira y Dosquebradas.
+
+Eso no es un detalle simpático. En una semana en la que la cifra oficial de fallecidos se publicó de cuatro maneras distintas la misma tarde por cuatro entidades distintas — todas honestas, todas cortando a horas diferentes — la marca de tiempo *es* el mecanismo de confianza.
+
+---
+
+## El agregador que no inventa nada
+
+Si quieres una prueba de que el efecto de red funciona sin que nadie tenga que morir, mira [AquíAyuda](https://www.aquiayuda.com/).
+
+Centraliza la información de ayuda del terremoto para todo el país: centros de acopio por municipio con qué necesitan y qué ya tienen, ayuda entre personas, todo ordenable por cercanía. Y lo hace **agregando fuentes ajenas** — Ayudas Pereira, Corag, Pereira Responde, Pereira Unida — sin inventar datos propios.
+
+Esa es la forma de la respuesta. No una app para gobernarlas a todas. Una capa especializada que lee a las demás con honestidad y agrega lo que ninguna podía hacer sola: una vista nacional.
+
+Solo funciona si las piezas de abajo son legibles. Por eso, de toda esta lista, las dos entradas que más me animan son las aburridas: [Pereira Responde](https://pereiraresponde.co/) publica una API pública documentada, y Corag publica una API pública sin autenticación más un servidor MCP remoto. No porque las APIs sean emocionantes, sino porque sobre una app con API se puede construir. Una app sin API es un callejón sin salida con buena interfaz.
+
+---
+
+## El mapa de la red
+
+Hace unos días la gente detrás de varias de estas herramientas se sentó a hablar. No para fusionarse — para dejar de pisarse. De esa conversación salió [corag.app/ecosystem](https://corag.app/ecosystem/), y es donde he puesto la mayor parte de mis propias horas.
+
+Es un directorio. Seis categorías: ayuda directa, reportes de daños, acopio y logística, mascotas, personas y el canal municipal. Cada entrada describe lo que la herramienta dice de sí misma, enlaza a ella, y anota si pudimos confirmar una API pública. La inclusión es por formulario y la revisa una persona.
+
+Dos cosas que insistí en dejar así, y en las que volvería a insistir:
+
+**Listar no es avalar.** La página lo dice explícitamente. En una emergencia donde [la Policía viene alertando sobre falsas campañas de donación y suplantación de organismos de socorro](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/), lo último que le sirve a alguien es un sello de confianza autoproclamado. Describir una herramienta no es responder por ella, y fingir lo contrario convertiría al directorio en parte del problema.
+
+**"Sin API confirmada" significa que no pudimos confirmarla, no que no exista.** La mayoría de estos equipos está agotada y produciendo. Ausencia de documentación no es ausencia de capacidad, y escribirlo al revés sería un golpe barato contra gente que hace el mismo trabajo que yo.
+
+La línea que está arriba en esa página es la que me quedaría si tuviera que botar todo lo demás: **No competimos. Nos alimentamos.**
+
+---
+
+## Una cosa más, y lo dejo ahí
+
+Vale la pena notarlo sin volverlo el tema del artículo: mientras el lado ciudadano estaba ocupado averiguando cómo interoperar, la respuesta nacional pasó por un debate público sobre lo contrario — Colombia [restringió inicialmente equipos internacionales de rescate](https://es.wikipedia.org/wiki/Terremoto_de_Colombia_de_2026), de México, China, El Salvador y OCHA de la ONU, con el argumento de que la capacidad nacional era suficiente. El equipo de 47 personas de Ecuador sí fue aceptado; las brigadas mexicanas llegaron por su cuenta.
+
+No tengo autoridad para juzgar esa decisión y no lo voy a intentar. Solo me cuesta ignorar que "¿dejamos que otros ayuden con esto?" fue la pregunta viva en los dos extremos de la respuesta, y que los dos extremos la contestaron distinto.
+
+---
+
+## Recursos
+
+- [corag.app/ecosystem — el directorio de apps de ayuda](https://corag.app/ecosystem/)
+- [AquíAyuda — agregador nacional de centros de acopio](https://www.aquiayuda.com/)
+- [Pereira Responde — mapa de daños con API pública](https://pereiraresponde.co/)
+- [DPL News — telcos, gobierno y plataformas activan medidas de emergencia](https://dplnews.com/terremoto-en-colombia-activan-medidas-emergencia/)
+- [El País — casi la mitad de las antenas móviles fuera de servicio](https://www.elpais.com.co/colombia/terremoto-en-colombia-casi-la-mitad-de-las-antenas-moviles-estan-fuera-de-servicio-estos-son-los-departamentos-mas-afectados-1143.html)
+
+---
+
+Veinte herramientas no son el problema. Veinte herramientas que no se pueden leer entre sí sí lo son, y ese problema tiene solución — es la única parte de toda esta catástrofe que está completamente en nuestras manos.
+
+A seguir construyendo.

--- a/src/content/blog/es/2026-08-27_the-map-of-the-network.md
+++ b/src/content/blog/es/2026-08-27_the-map-of-the-network.md
@@ -1,0 +1,148 @@
+---
+title: 'El mapa de la red'
+description: 'Recorrido por las veinte herramientas ciudadanas que responden al terremoto en Colombia, categoría por categoría. Una descripción, no un ranking.'
+pubDate: '2026-08-27'
+tags: ['tech', 'civic-tech', 'colombia', 'web-development']
+keywords: ['directorio de apps de ayuda terremoto Colombia', 'Pereira Responde API', 'Gravitas mapa Colombia', 'Encontrados.co personas desaparecidas', 'AquíAyuda centros de acopio', 'herramientas ciudadanas emergencia', 'plataformas de código abierto terremoto']
+series: 'colombia-earthquake-2026'
+seriesOrder: 4
+draft: true
+---
+
+Antes que nada, el encuadre, porque cambia cómo deberías leer cada párrafo de abajo.
+
+**Esto es una descripción, no un ranking.** Cada resumen sale de lo que cada herramienta dice de sí misma en su propio sitio público. No he auditado el código, la disponibilidad, la calidad de datos ni el gobierno de nadie. Nadie está siendo certificado. Nadie está siendo recomendado por encima de otro.
+
+**Listar no es avalar.** [El directorio en el que se basa este artículo](https://corag.app/ecosystem/) lo dice en la propia página, y quiero repetirlo acá, porque la Policía viene [alertando sobre falsas campañas de donación y suplantación de organismos de socorro](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/) desde la primera semana. Un sello de confianza autoproclamado empeoraría esto, no lo mejoraría.
+
+**"Sin API pública confirmada" significa exactamente eso.** Significa que no encontré documentación. La mayoría de estos equipos lleva días sin dormir. Ausencia de documentación no es ausencia de capacidad.
+
+**Acá no aparece ningún dato personal.** Algunas de estas herramientas manejan reportes de personas desaparecidas. Describo la herramienta. Nunca describo un caso.
+
+Aclarado eso.
+
+---
+
+## Ayuda directa y matching
+
+Herramientas donde una persona publica una necesidad o un ofrecimiento y el sistema intenta conectarlos.
+
+**[Corag Ayuda Directa](https://ayuda.corag.app)** — mapa vivo de solicitudes y personas disponibles. Publicas una necesidad o un ofrecimiento con contacto consentido, y las entregas quedan con evidencia pública. Documenta una API pública sin autenticación y un servidor MCP remoto. Es en la que yo he estado aportando, y por eso el siguiente artículo lo voy a dedicar a desarmar sus decisiones técnicas en vez de elogiarlas acá.
+
+**[Pereira Unida](https://pereiraunida.com/)** — coordinación de ayuda ciudadana en Pereira y Dosquebradas: alimentos, herramientas, medicinas, voluntariado, red familiar, acopio.
+
+**[SOS Terremoto](https://conectando-ayudas-colombia.com/)** — tablero compartido para publicar y atender solicitudes de ayuda.
+
+**[Help Them Directly](https://helpthemdirectly.org/en/)** — directorio voluntario que conecta donantes con familias que recaudan para sí mismas. Su campaña principal es el terremoto de Venezuela 2026, con un formulario para Colombia al lado. Detalle importante, y lo dice el propio sitio: **no administra dinero.** Cada familia maneja sus propios canales.
+
+---
+
+## Daños y reportes
+
+La categoría más grande, lo cual tiene sentido — después de un terremoto, la primera pregunta de todo el mundo es *si este edificio es seguro*.
+
+**[Pereira Responde](https://pereiraresponde.co/)** — mapa ciudadano de daños en infraestructura de Pereira: edificios, vías, puntos de apoyo. Hasta tres fotos por reporte, más atajos a acopio y albergues cercanos. Publica una **API pública documentada** en `/api/docs`, lo que la mete en un club muy pequeño.
+
+**[SismoVision](https://sismovision.com/)** — reportes ciudadanos de daño estructural, en concreto grietas, con orientación preliminar. El sitio es explícito en que esto no reemplaza una inspección profesional, y ese encuadre importa: la distancia entre "una herramienta me dijo que mi muro probablemente está bien" y "un ingeniero certificó mi edificio" es donde la gente se hace daño.
+
+**[Mapa del terremoto](https://www.mapadelterremoto.com/)** — mapa abierto de daños del sismo del 10 de agosto: puntos de daño, albergues y acopio en varias ciudades.
+
+**[Reporte CO](https://co.crafter.run/)** — plataforma abierta con privacidad por diseño que mapea daños, personas atrapadas o heridas, albergues y fallas de servicios.
+
+**[Terremoto Colombia](https://terremotocolombia.co/)** — reportes, mapa de daños y enlaces a fuentes oficiales. Se describe como plataforma ciudadana libre y de código abierto para conectar reportes, recursos y equipos de respuesta, y como iniciativa independiente y no partidista.
+
+**[Gravitas](https://mapa.gravitasworld.com/)** — mapeo ciudadano en tiempo real de edificios, centros de acopio y logística. Más sobre esta abajo.
+
+---
+
+## Acopio y logística
+
+Dónde está lo físico, qué le falta y cómo moverlo.
+
+**[AquíAyuda](https://www.aquiayuda.com/)** — hub nacional: centros de acopio por municipio mostrando qué falta y qué está cubierto, ayuda entre personas, ordenable por cercanía. **Agrega fuentes ajenas** (Ayudas Pereira, Corag, Pereira Responde, Pereira Unida) sin inventar datos.
+
+**[Acopio / Ayudas Pereira](https://alluda.online/)** — centros de acopio por ciudad, con visibilidad de faltantes y excedentes, más registro de voluntarios y transportadores.
+
+**[Unidos por Pereira](https://unidosporpereira.com/)** — albergues, acopio, comidas, ayuda y mascotas, organizados por tema, cada uno con hora de última actualización.
+
+**[Pereira Ayuda](https://pereiraayuda.com/)** — directorio fechado de albergues, puntos de donación y hospitales abiertos en Pereira y Dosquebradas.
+
+**[ayuda.red](https://ayuda.red/)** — mapa de infraestructura de ayuda más un registro de desaparecidos, canales de donación y guías oficiales.
+
+**[Mapa de Ayuda — Gogó](https://soygogo.com/pereira-ayuda)** — puntos de ayuda en Pereira.
+
+**[PereiraVive](https://pereiravive.com/)** — y esta merece más atención de la que está recibiendo.
+
+Es un tablero comunitario y gratuito de arriendos para Pereira y municipios cercanos. Puedes buscar vivienda, publicar un aviso, fotografiar un letrero de "se arrienda" que viste en la calle y subirlo — y **reportar precios abusivos**. Sin cuenta.
+
+Piensa en lo que significa esa última función. Entre cuarenta mil y ciento cuarenta mil personas de esta ciudad necesitan de repente dónde vivir, todas la misma semana. Ese es el escenario de manual para que los arriendos se dupliquen de un día para otro. Alguien miró eso y construyó una forma de que los vecinos lo denuncien públicamente. Es la pieza de software más silenciosamente furiosa de toda esta lista y me tomó tres pasadas por el directorio darme cuenta de que estaba ahí.
+
+El sitio deja claro que es un tablero comunitario, no una inmobiliaria: verifica el inmueble en persona, no pagues por adelantado.
+
+---
+
+## Mascotas
+
+**[Encuentra tu mascota](https://encuentratumascota.co/anuncios/se-busca)** — clasificados de "se busca" para reunir mascotas con su familia.
+
+He visto gente en redes tratar esta categoría como algo frívolo. No lo es. Los equipos oficiales de rescate sacaron catorce animales de los escombros en Pereira. Para una familia que perdió la casa, el perro no es una nota al pie.
+
+---
+
+## Personas
+
+La categoría más delicada por mucho, y donde las decisiones de diseño cuestan más caro.
+
+**[Encontrados.co](https://encontrados.co/)** — hecha para rescatistas. Fotografías a alguien que está a tu cuidado, el sistema lo cruza contra reportes de desaparecidos, y **la foto se borra después del match**. Las familias también pueden reportar. Se construyó con voluntarios de Ni500 / Torrenegra.
+
+Ese borrado es el diseño entero. El dato más valioso de este sistema es también el que más necesita dejar de existir un minuto después de lo necesario — fotografías de personas heridas, desorientadas o inconscientes, tomadas sin su consentimiento porque el consentimiento no era posible. Construir el paso de borrado desde el principio, en una semana, bajo esta presión, es la mejor decisión de ingeniería que he visto salir de esta emergencia.
+
+**[SOS Pereira 2026](https://sospereira.com/)** — el portal ciudadano de la Alcaldía: reportes de desaparecidos, reporte de daños en edificaciones, censo de empresarios afectados, listados públicos y acceso para operadores.
+
+Esta es de la Alcaldía. No es de Corag ni un proyecto de voluntarios. Lo digo de frente porque los directorios difuminan los orígenes, y confundir un canal municipal con una herramienta ciudadana les hace un flaco favor a los dos.
+
+---
+
+## La que tiene el método mejor documentado
+
+De todo lo que hay acá, [Gravitas](https://mapa.gravitasworld.com/) es el caso que le mostraría a alguien que construye software, en parte porque [El Colombiano lo documentó](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) y así no dependo de mi propia lectura.
+
+Juan Camilo Garzón es diseñador y antropólogo, de Risaralda. Su estudio, Senza Create, llevaba cuatro años trabajando en turismo rural. Después del terremoto rehicieron la plataforma para uso de emergencia en **42 horas**.
+
+Lo que integra: reportes ciudadanos, datos satelitales y georreferenciados de Copernicus, redes sociales, grupos oficiales de WhatsApp, y reportes de gobierno y alcaldías. Al momento de esa nota había recibido unos 250 reportes ciudadanos y 850 internos.
+
+La parte que vale la pena robarse es cómo deciden qué es cierto. En palabras del propio Garzón:
+
+> *"Si cinco personas reportan el mismo centro de acopio, eso nos ayuda a determinar que la información es verídica, más que un solo reporte que puede parecer inusual o no tener respaldo."*
+
+Umbral de corroboración más IA más un administrador revisando antes de que algo llegue al mapa. No es "la IA decide". Es IA reduciendo el campo y un humano cerrándolo. Cualquiera que haya construido un sistema de reportes ciudadanos termina reinventando alguna versión de esto, normalmente después de quemarse. Ellos llegaron ahí en menos de dos días.
+
+---
+
+## Lo que falta en este mapa
+
+Un directorio honesto debería decir qué no alcanza a ver.
+
+No sé cuáles de estas herramientas van a seguir funcionando en tres meses. No conozco sus políticas de retención de datos más allá de lo que publican. No sé cuántas entradas de centros de acopio están desactualizadas en este momento, en ninguna de ellas, incluidas las que yo ayudo a mantener. Nadie ha auditado el traslape para ver cuántos reportes están duplicados en cuatro mapas porque el mismo vecino los subió en cuatro lados.
+
+Y no sé — nadie sabe — si algo de esto cambió el desenlace para una sola persona. Me gustaría creer que sí. No lo puedo demostrar, y esta no es una serie donde me dé el lujo de afirmar cosas que no puedo demostrar.
+
+Si manejas una de estas y la describí mal, [el directorio tiene un formulario](https://corag.app/ecosystem/), y una persona lee cada envío.
+
+---
+
+## Recursos
+
+- [corag.app/ecosystem — el directorio vivo](https://corag.app/ecosystem/)
+- [El Colombiano — la plataforma con IA que organiza ayudas, voluntarios y recursos](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222)
+- [Documentación para desarrolladores de Corag](https://corag.app/developers)
+- [Documentación de la API de Pereira Responde](https://pereiraresponde.co/api/docs)
+- [Recomendaciones de la Policía Nacional para evitar estafas con donaciones](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/)
+
+---
+
+Veinte herramientas, seis categorías, un supuesto compartido: que la pieza del otro vale más leerla que reconstruirla.
+
+Ese supuesto es más joven que la emergencia. Falta ver si le sobrevive.
+
+A seguir construyendo.

--- a/src/content/blog/es/2026-08-31_building-software-in-an-emergency.md
+++ b/src/content/blog/es/2026-08-31_building-software-in-an-emergency.md
@@ -1,0 +1,143 @@
+---
+title: 'Construir software en una emergencia'
+description: 'Nueve cosas que aprendí haciendo software de ayuda tras el terremoto: datos que caducan, PII, una API pública sin autenticación, y qué haría distinto.'
+pubDate: '2026-08-31'
+tags: ['tech', 'civic-tech', 'ai-agents', 'mcp', 'web-development']
+keywords: ['construir software en un desastre', 'API pública sin autenticación ventajas y riesgos', 'idempotencia source externalId', 'servidor MCP para emergencias', 'privacidad datos personas desaparecidas', 'apps offline first emergencia', 'frescura del dato timestamps API']
+series: 'colombia-earthquake-2026'
+seriesOrder: 5
+draft: true
+---
+
+Este es el artículo que más he reescrito, porque la versión honesta siempre termina siendo menos halagadora que el primer borrador.
+
+La versión fácil dice: los desarrolladores respondimos rápido, la IA nos dejó construir aplicaciones enteras en horas, qué impresionante. Todo eso es cierto y algo de eso ya lo dije. Pero si lo único que me llevo de esto es que fuimos rápidos, no aprendí nada que valga la pena escribir.
+
+Así que van nueve cosas, en el orden en que me las encontré, incluidas las que todavía no me dejan tranquilo.
+
+---
+
+## 1. El dato caduca, y fingir lo contrario es el modo de falla
+
+Todo lo operativo en esta emergencia tenía una vida útil que se medía en horas. Un centro de acopio deja de recibir. Un albergue se llena. Un hospital reabre. Una vía se despeja. Un edificio que ayer estaba bien recibió una réplica de 4,8 de madrugada.
+
+El instinto cuando estás produciendo rápido es renderizar el dato limpio y seguir. La jugada correcta es más fea: **muestra la marca de tiempo, siempre, incluso cuando te avergüence.** "Actualizado hace 6 horas" es más útil que una tarjeta bonita que insinúa una frescura que no tiene.
+
+[Unidos por Pereira](https://unidosporpereira.com/) y [Pereira Ayuda](https://pereiraayuda.com/) lo hicieron bien desde el primer día. Yo lo noté antes de copiarlo, lo cual es su propia lección pequeña.
+
+El corolario es más duro: si no puedes refrescar un conjunto de datos, dilo, o bájalo. Un directorio desactualizado que parece vivo manda a alguien a cruzar la ciudad, en una semana sin gasolina y con circulación vehicular restringida, hasta una puerta cerrada.
+
+---
+
+## 2. Producir rápido contra no hacer daño
+
+Esta es la tensión de verdad y no se resuelve limpiamente.
+
+La lista de lo que un desarrollador no debería hacer en una emergencia resultó mucho más específica de lo que esperaba:
+
+- **No hagas scraping de datos personales.** Los listados de personas desaparecidas son públicos en un contexto específico y para un propósito específico. Copiarlos a tu propia base porque "ayuda al cruce" crea un registro permanente que nadie consintió.
+- **No publiques teléfonos privados**, aunque alguien haya puesto el suyo en un grupo de WhatsApp. Un grupo de 400 no es la internet pública.
+- **No prometas lo que no puedes sostener.** Si tu app insinúa que alguien va a aparecer, alguien tiene que aparecer de verdad.
+- **No inventes rankings de confianza.** Nada de listas de "ONG verificadas", ni sellos, ni calificaciones de organizaciones de socorro. No tienes la autoridad, y la Policía ya está lidiando con [gente suplantando organismos de socorro y funcionarios públicos](https://www.elcolombiano.com/colombia/terremoto-alerta-por-estafadores-policia-suplantacion-director-sanidad-damnificados-EG39953869).
+- **No pongas un botón hacia un canal que no verificaste hoy.**
+
+El mejor contraejemplo de todo este ecosistema es [Encontrados.co](https://encontrados.co/), al que sigo volviendo. Los rescatistas fotografían a alguien que está a su cuidado, el sistema lo cruza contra reportes de desaparecidos, y **la foto se borra después del match**. El dato más valioso del sistema es también el que más necesita dejar de existir. Construyeron el borrado desde el principio, en una semana, bajo presión. Esa es la vara.
+
+---
+
+## 3. La API pública sin autenticación — la decisión de la que menos seguro estoy
+
+Corag documentó una **API pública sin autenticación** durante la emergencia. Cualquiera puede leer la base de necesidades y cualquiera puede escribir en ella. El razonamiento era directo: la fricción es el enemigo cuando otros equipos están intentando integrarse a las 2 de la mañana, y un proceso de solicitud de API key que nadie atiende equivale a no tener API.
+
+Creo que fue la decisión correcta para las primeras semanas. También creo que es la que peor defendería en una sala tranquila, y quiero dejar escrito el trade-off real en vez de la versión de folleto.
+
+**Lo que ganas:** una base sobre la que cualquiera puede construir de verdad. Bots, tableros, otras PWAs y agregadores pueden leer y escribir sin pedir permiso ni esperar a nadie. Así es como [AquíAyuda](https://www.aquiayuda.com/) termina jalando de cuatro fuentes.
+
+**A qué quedas expuesto:** spam, envenenamiento de datos, y a que alguien inunde el mapa con necesidades falsas para hacer ver un barrio como desatendido. Nada lo impide estructuralmente. Todas las mitigaciones quedan aguas abajo — corroboración, revisión humana, límites de tasa — y las mitigaciones aguas abajo son las que construyes después de que algo salió mal.
+
+**Qué haría distinto, en frío:** dejar las lecturas abiertas y poner la escritura detrás de algo barato. No un formulario de solicitud — algo automático, tipo un token por fuente que puedas emitirte solo y que se revoque cuando una fuente se porte mal. Conservas la propiedad de fricción cero y ganas trazabilidad. No empujé por eso en la semana uno porque la semana uno no era la semana para eso, y honestamente no sé si eso fue buen criterio o una racionalización.
+
+---
+
+## 4. La idempotencia es la diferencia entre integrar y duplicar
+
+De esta sí estoy seguro, y es el punto menos glamoroso de la lista.
+
+Cuando cinco clientes distintos pueden escribir la misma necesidad en la misma base, vas a terminar con la misma necesidad cinco veces a menos que la API se niegue. La API pública de Corag es idempotente por diseño: cada escritura lleva un `source` y un `externalId`, y ese par siempre resuelve al mismo registro.
+
+Eso es todo. Ese es el mecanismo completo. Y es la diferencia entre una base compartida y un botadero.
+
+Sin eso, cada integración empeora los datos. Con eso, un agregador puede resincronizar cada diez minutos sin miedo, y un equipo que se cayó un día puede reproducir todo lo que se perdió. Si estás construyendo algo en lo que otros van a escribir, esto es lo primero que hay que hacer bien y en el día uno no cuesta casi nada. En el día treinta cuesta una migración y un script de deduplicación.
+
+---
+
+## 5. MCP, o qué pasa cuando el cliente no es una persona
+
+Corag también expone un servidor MCP remoto, con herramientas del estilo *listar emergencias*, *publicar una solicitud*, *publicar un ofrecimiento*.
+
+Si todavía no te has topado con MCP: es un protocolo que le permite a un agente de IA descubrir y llamar herramientas — más o menos lo que una especificación OpenAPI hace por un desarrollador, salvo que el consumidor es un modelo y no una persona escribiendo código de integración.
+
+Por qué esto importa en una emergencia no tiene que ver con la palabra de moda. Tiene que ver con que el conjunto de personas que podría consultar útilmente la base de necesidades es mucho más grande que el conjunto de personas capaces de escribir un cliente HTTP. Una coordinadora de voluntarios con un agente puede preguntar "qué se necesita en Dosquebradas ahora mismo" y obtener una respuesta real de la base viva, sin que nadie le construya un tablero. Un bot de WhatsApp de un barrio puede publicar una solicitud sin que un desarrollador lo cablee.
+
+Voy a ser honesto: esta es la pieza en la que es más probable que me esté equivocando sobre el impacto. Es lo más nuevo y menos probado de la lista. Pero de todo lo que sacamos, es lo que me hizo pensar que lo que está cambiando es la forma del software cívico, y no solo su velocidad.
+
+---
+
+## 6. Verificación por corroboración, con un humano cerrando
+
+Ya hablé de [Gravitas](https://mapa.gravitasworld.com/) en el artículo anterior, pero el patrón también va acá porque es la parte reutilizable.
+
+Su regla, [como se la describió Juan Camilo Garzón a El Colombiano](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222): cinco personas reportando el mismo centro de acopio suben la confianza mucho más que un reporte solitario que se ve raro o sin respaldo. La IA reduce, un administrador confirma, y ahí sí llega al mapa.
+
+Lo que quiero subrayar es la dirección del ciclo. El modelo no es quien decide. El modelo es el filtro que hace manejable la revisión humana cuando llegan 850 reportes y son cuatro personas.
+
+Cualquiera que construya reportes ciudadanos termina llegando a alguna versión de esto, normalmente después de publicar algo falso. Ellos llegaron en 42 horas.
+
+---
+
+## 7. Diseña para una red que no está
+
+**Más de 3.400 estaciones base móviles fuera de servicio.** El 46,1 % de las estaciones revisadas en siete departamentos. Es dato del MinTIC, y es la restricción que debió haberlo condicionado todo y en general no lo hizo.
+
+Si tu app asume conexión viva, no funciona el día que importa. Lo que eso implica en concreto: cargas pequeñas, caché agresivo, un estado offline de solo lectura que sirva, no bloquear en scripts de terceros y — esta es la parte que a los ingenieros nos cuesta — una respuesta a "¿cómo llega esta información a alguien que no tiene señal?".
+
+La respuesta honesta para la mayoría de estas herramientas, incluidas en las que yo trabajé, es *no llega*. Llega a alguien que sí tiene señal y que después camina hasta allá y le cuenta. Lo cual está bien, siempre que diseñes sabiendo que ese es el último salto, y no construyas como si el celular en el albergue fuera el destino final.
+
+---
+
+## 8. No reconstruyas el mapa de acopio
+
+El impulso más fuerte en las primeras 48 horas es construirlo todo tú, porque integrarse con el proyecto a medio terminar de otro se siente más lento que arrancar limpio.
+
+No lo es, y la cuenta no está ni cerca. Cuatro equipos construyendo cuatro mapas de acopio producen cuatro conjuntos de datos incompletos y cuatro grupos de usuarios confundidos. Un equipo construyendo un mapa y tres equipos leyendo su API producen un conjunto de datos que mejora cada hora.
+
+La revisión que aplicaría ahora, antes de escribir una línea: *¿esto ya existe y, si existe, tiene alguna forma de que yo lo lea?* Si ambas son sí, construye encima. Si la primera es sí y la segunda no, escríbele al equipo — la mayoría te pasa un endpoint JSON si se lo pides, porque no están compitiendo contigo, están agotados.
+
+---
+
+## 9. Qué hizo la IA de verdad, y qué no
+
+De lo que todo el mundo quiere hablar es de que se construyeron aplicaciones enteras en horas. Eso pasó. [Gravitas se rehízo en 42 horas](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) por un estudio que venía trabajando en turismo rural. Existen más de veinte herramientas que hace tres semanas no existían. Parte de esa velocidad es inequívocamente nueva, y no creo que a nadie que haya vivido esta semana lo convenzan de lo contrario.
+
+Esto es lo que pongo al lado.
+
+Nadie puede demostrar que algo de esto salvó una vida. Ni Corag, ni ninguna de las otras. El conteo de desaparecidos [bajó de 379 a 143](https://www.eltiempo.com/colombia/otras-ciudades/balance-oficial-de-la-ungrd-tras-terremoto-de-magnitud-7-4-en-colombia-273-fallecidos-3-824-heridos-y-377-desaparecidos-3578196) entre el 13 y el 15 de agosto — cientos de personas encontradas — y me encantaría reclamar una tajada de eso. No puedo. El cruce que produjo esa cifra ocurrió entre hospitales, albergues, registros oficiales, redes familiares y, en algún punto de la mezcla, software. Desenredar la contribución no es posible, y fingir lo contrario sería exactamente la conducta contra la que argumenta esta serie.
+
+Lo que la IA sí hizo con claridad fue acortar la distancia entre *a alguien se le ocurre una herramienta* y *la herramienta existe*. Eso es real y es enorme. Lo que no hizo fue decidir qué construir, decidir qué es cierto, ni responder por una respuesta equivocada. Esas tres se quedaron enteras con nosotros, y esta semana me hizo pensar que se van a quedar más tiempo del que asume la conversación actual.
+
+---
+
+## Recursos
+
+- [Documentación para desarrolladores de Corag](https://corag.app/developers)
+- [Especificación OpenAPI pública de Corag](https://ayuda.corag.app/api/public/openapi.json)
+- [Servidor MCP de Corag](https://ayuda.corag.app/mcp)
+- [Documentación de la API de Pereira Responde](https://pereiraresponde.co/api/docs)
+- [El Colombiano — cómo verifica Gravitas los reportes ciudadanos](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222)
+- [Plan de contingencia del MinTIC para las comunicaciones](https://laopinion.co/colombia/mintic-activa-plan-de-contingencia-para-garantizar-las-comunicaciones-tras-terremoto)
+
+---
+
+El resumen incómodo es que las partes difíciles de esto nunca fueron técnicas. Producir fue lo fácil. Decidir qué merecía existir, qué merecía borrarse y qué no teníamos derecho a reclamar — ahí estuvo todo el trabajo real.
+
+A seguir construyendo. Con cuidado.

--- a/src/content/blog/es/2026-09-03_what-comes-next-after-the-earthquake.md
+++ b/src/content/blog/es/2026-09-03_what-comes-next-after-the-earthquake.md
@@ -1,0 +1,130 @@
+---
+title: 'Lo que sigue'
+description: 'La fase de rescate dura semanas y la reconstrucción dura años. Cómo ayudar hoy, cómo no caer en estafas, y qué sobrevive cuando se apagan las cámaras.'
+pubDate: '2026-09-03'
+tags: ['tech', 'personal', 'civic-tech', 'colombia']
+keywords: ['cómo ayudar a los damnificados del terremoto', 'evitar estafas con donaciones Colombia', 'cuánto cuesta la reconstrucción tras el terremoto', 'cómo aportar a proyectos de tecnología cívica', 'recuperación a largo plazo desastres', 'datos abiertos después de una emergencia', 'plan de reconstrucción Pereira']
+series: 'colombia-earthquake-2026'
+seriesOrder: 6
+draft: true
+---
+
+La fase de rescate de un desastre dura unas dos semanas. La reconstrucción dura años, y para el tercer mes casi nadie está mirando.
+
+De esa brecha quiero hablar, porque todo lo que aparece en esta serie se construyó durante las dos semanas.
+
+---
+
+## Dónde va la reconstrucción de verdad
+
+El Gobierno declaró desastre nacional mediante el **Decreto 1171 del 11 de agosto de 2026**, seguido de tres días de duelo nacional y del anuncio de una emergencia económica para financiar la reconstrucción. A las familias afectadas se les prometieron subsidios de arriendo, suspensión de facturas de servicios y un mes de prórroga en las declaraciones tributarias.
+
+Cuánto cuesta todavía está sin resolver, y prefiero mostrarte el rango en vez de escoger un número:
+
+| Fuente | Estimación |
+|--------|-----------|
+| Estimaciones preliminares del Gobierno (vía Portafolio) | $20 billones COP, ~1 % del PIB |
+| La República | US$6.350 millones, 1 % del PIB |
+| Oxford Economics | US$990 – US$1.980 millones, 0,2–0,4 % del PIB |
+| Modelo PAGER del USGS | 34 % de probabilidad de pérdidas entre US$1.000 y US$10.000 millones |
+
+Esas cifras se contradicen por un orden de magnitud, y la razón no es que alguien mienta. Miden cosas distintas. Unas cuentan daño físico directo; otras, pérdida económica total incluyendo la actividad que no va a ocurrir; las del USGS son modelos probabilísticos automáticos publicados en las primeras horas, antes de que existiera censo alguno. Cualquiera que cite una de ellas como *el* número te está diciendo más sobre su argumento que sobre el daño.
+
+En lo local: el gobernador de Risaralda, Juan Diego Patiño Ochoa, anunció que solicitaría unos **$67 mil millones COP** del sistema de regalías, dirigidos sobre todo a vivienda e infraestructura educativa. El censo de edificaciones de Pereira arrancó el 12 de agosto y es lo que con el tiempo va a convertir todo esto de estimación en hecho.
+
+A nivel nacional: 81.506 viviendas averiadas y 14.493 destruidas, más 298 vías, 44 puentes, 59 acueductos, 241 centros de salud y 2.612 instituciones educativas.
+
+Esas dos últimas categorías son la razón por la que esto no se acaba en un año.
+
+---
+
+## Si eres vecino
+
+Arranca por la categoría, no por un enlace que te reenviaron. [El directorio](https://corag.app/ecosystem/) está organizado por lo que de verdad necesitas: albergues y acopio, reporte de daños, personas, mascotas, vivienda, ayuda directa.
+
+Dos cosas concretas que vale la pena conocer y que casi nadie tiene en el radar:
+
+- **[PereiraVive](https://pereiravive.com/)** es un tablero comunitario y gratuito de arriendos, y permite **reportar precios abusivos**. Si te acaban de doblar el arriendo, ahí es donde queda constancia.
+- **[Encuentra tu mascota](https://encuentratumascota.co/anuncios/se-busca)** existe y funciona. Solo los equipos oficiales sacaron catorce animales de los escombros en Pereira.
+
+Y revisa la fecha de cualquier dato operativo antes de moverte. Las necesidades de un centro de acopio cambian en cuatro horas.
+
+---
+
+## Si manejas una organización o un punto de acopio
+
+Publica qué necesitas, publica también de qué te sobra, y **publica la hora en que actualizaste**.
+
+La mitad del excedente importa más de lo que la gente cree. Un centro ahogado en ropa usada mientras tres cuadras más allá otro no tiene agua es la falla más común de todo este sistema, y es enteramente un problema de información.
+
+Si puedes exponer tus datos en cualquier formato legible por máquina — así sea un archivo JSON que regeneras a mano dos veces al día — los agregadores pueden jalar de ti en vez de transcribirte. Esa es la diferencia entre estar en un mapa y estar en seis.
+
+---
+
+## Si eres desarrollador
+
+**Lee antes de escribir.** Pregúntate si la cosa ya existe, y después si la puedes leer. [Pereira Responde publica una API documentada](https://pereiraresponde.co/api/docs). [La API pública de Corag](https://corag.app/developers) es sin autenticación e idempotente, con un servidor MCP al lado. Si una herramienta sobre la que quieres construir no tiene documentación pública, escríbele al equipo — la mayoría te pasa un endpoint, porque no están compitiendo contigo.
+
+**Haz las escrituras idempotentes desde el día uno.** `source` + `externalId`. No cuesta nada ahora y cuesta una migración después.
+
+**Ponle marca de tiempo a todo.**
+
+**No toques datos personales que no necesites**, y borra los que sí necesitas apenas termine el trabajo — como [Encontrados.co](https://encontrados.co/) borra la foto después del match.
+
+**Propón tu herramienta al directorio** si no está. Hay un formulario, lo lee una persona, y la inclusión no es automática. Y si encuentras algo mal descrito en el listado — incluido cualquier cosa que yo haya escrito en esta serie — dilo.
+
+**No silencies las otras piezas.** En este ecosistema nadie gana por quedar de último en pie.
+
+---
+
+## Antes de donar
+
+La Policía, a través de la DIJÍN, viene alertando desde la primera semana sobre un conjunto de estafas específicas, y vale la pena conocerlas por nombre:
+
+- **Suplantación de organismos de socorro**, líderes sociales y funcionarios públicos, con falsas campañas de recolección. El Colombiano documentó [a alguien haciéndose pasar por director de Sanidad](https://www.elcolombiano.com/colombia/terremoto-alerta-por-estafadores-policia-suplantacion-director-sanidad-damnificados-EG39953869).
+- **La llamada del familiar atrapado.** Alguien llama diciendo que tu familiar está atrapado o gravemente herido, para que el pánico te haga enviar dinero de inmediato.
+- **Enlaces fraudulentos** por WhatsApp, SMS y redes sociales.
+
+La recomendación oficial es validar por canales que puedas verificar de forma independiente: Cruz Roja, alcaldías, gobernaciones, Defensa Civil.
+
+Agrego una mía, ya que la serie lleva seis artículos defendiéndola: **prefiere a quien te muestre evidencia de entrega antes que a quien te cuente la historia más urgente.** La urgencia es fácil de fingir. Un registro de entrega, menos.
+
+A propósito no publico números de cuenta ni enlaces de pago en ninguna parte de esta serie. Si alguien lee esto en seis meses, cualquier canal que yo hubiera listado pudo haber cambiado de manos.
+
+---
+
+## Qué sobrevive cuando se apagan las cámaras
+
+Esta es la parte que de verdad me preocupa.
+
+Más de veinte herramientas se construyeron en unas dos semanas. Varias las hicieron dos o tres personas, de noche, a punta de adrenalina, sin financiación y sin plan más allá de la emergencia. [Gravitas se adaptó en 42 horas](https://www.elcolombiano.com/tecnologia/plataforma-ia-organiza-ayudas-voluntarios-recursos-terremoto-colombia-KC39918222) por un estudio cuyo negocio real es el turismo rural. En algún momento ese estudio tiene que volver al turismo rural.
+
+La reconstrucción va para años. Nada de esta lista se construyó para durar años. Ese desfase no es un reproche a nadie — construir para la emergencia era lo correcto — pero es un problema real que llega en una fecha predecible.
+
+No creo que la respuesta sea que las veinte se vuelvan productos sostenibles. La mayoría no lo hará, ni debería. Algunas ya son redundantes. Algunas resolvieron un problema que solo existió la semana uno.
+
+Lo que yo creo que sobrevive son **los datos y las interfaces hacia ellos**. Un mapa es una renderización; el conjunto de datos de edificaciones dañadas, puntos de acopio, albergues y vivienda es el activo. Si esos datos son abiertos, documentados y legibles, cuando un mantenedor se queme o un dominio se venza, otro los puede retomar en una tarde. Si están encerrados dentro de una SPA sin API, se mueren con el proyecto y la próxima vez empezamos de cero.
+
+Así que lo útil en el mes dos, en mi opinión, es poco glamoroso: sacar los datos de debajo de las interfaces. Documentar los endpoints. Escribir el esquema. Entregarle el histórico a alguien institucional — una universidad, la alcaldía, quien sea que todavía vaya a existir en 2029.
+
+Esa es la versión donde el próximo terremoto arranca desde algo en vez de desde nada. Y va a haber un próximo. Colombia tiene unos 2.500 eventos sísmicos al mes, no los podemos predecir, y la única variable que controlamos es lo que hayamos construido y lo que hayamos dejado escrito.
+
+---
+
+## Recursos
+
+- [corag.app/ecosystem — el directorio vivo](https://corag.app/ecosystem/)
+- [Policía Nacional — cómo evitar estafas en emergencias](https://www.eluniversal.com.co/sucesos/2026/08/14/terremoto-en-colombia-evite-estafas-en-emergencias-y-desastres-policia-da-estas-recomendaciones/)
+- [Portafolio — la estimación inicial del costo de reconstrucción](https://www.portafolio.co/economia/reconstruir-a-colombia-tras-el-terremoto-tendria-un-costo-inicial-de-20-billones-segun-estimaciones-preliminares-500175)
+- [LA FM — Risaralda busca regalías para vivienda e infraestructura educativa](https://www.lafm.com.co/actualidad/risaralda-reconstruccion-viviendas-terremoto-colombia-2026-sesenta-y-siete-mil-millones-de-pesos-regalias-408019)
+- [Documentación para desarrolladores de Corag](https://corag.app/developers)
+
+---
+
+En el primer artículo escribí que Pereira no se quedó en silencio noventa segundos — se quedó en silencio tres días, y lo que terminó llenando ese silencio fue gente apareciendo con lo que tenía.
+
+Aparecer nunca fue la parte difícil. Los colombianos somos extremadamente buenos para las primeras dos semanas. En lo que históricamente somos peores es en el mes siete, cuando la noticia ya se movió y la familia del albergue sigue en el albergue.
+
+Lo que vayamos a dejar de todo esto — los datos, el código, la costumbre de leer el trabajo del otro en vez de reconstruirlo — hay que construirlo ahora, mientras a todo el mundo todavía le importa.
+
+A seguir construyendo.

--- a/src/content/series/colombia-earthquake-2026.md
+++ b/src/content/series/colombia-earthquake-2026.md
@@ -1,0 +1,7 @@
+---
+name: "colombia-earthquake-2026"
+title: "When Colombia Shook"
+description: "A magnitude 7.4 earthquake hit western Colombia on August 10, 2026. Among the cities affected, Pereira — my city — was one of the hardest hit. This is what happened, why the buildings that fell fell, and how dozens of developers answered with solutions in a matter of hours."
+order: 11
+keywords: ["2026 Colombia earthquake", "Pereira earthquake", "San José del Palmar Chocó earthquake", "civic tech emergency response", "disaster response apps Colombia", "NSR-10 seismic code", "Armenia 1999 earthquake comparison", "open APIs emergency", "MCP disaster response"]
+---

--- a/src/content/tags/civic-tech.md
+++ b/src/content/tags/civic-tech.md
@@ -1,0 +1,7 @@
+---
+name: "civic-tech"
+description: "Civic technology — software built by and for communities: emergency response tools, open data, public-interest platforms, and volunteer-built infrastructure."
+tier: secondary
+order: 14
+parent: "tech"
+---

--- a/src/content/tags/colombia.md
+++ b/src/content/tags/colombia.md
@@ -1,0 +1,7 @@
+---
+name: "colombia"
+description: "Colombia — Pereira, the Eje Cafetero, and the local tech community I build from."
+tier: secondary
+order: 15
+parent: "personal"
+---

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -1089,6 +1089,7 @@ I currently focus on AI applications, developer productivity, and high-impact pr
     'slides-as-code': 'Slides as Code',
     'the-mythos-saga': 'The Mythos Saga',
     'playing-with-time': 'Playing With Time',
+    'colombia-earthquake-2026': 'When Colombia Shook',
   },
   seriesDescriptions: {
     'building-xergioalex':
@@ -1113,6 +1114,8 @@ I currently focus on AI applications, developer productivity, and high-impact pr
       "Following Anthropic's Mythos-class models from 'too dangerous to release' to available to everyone — and what frontier AI capability means for the rest of us.",
     'playing-with-time':
       'Science, paradoxes, and fiction — what really happens when you mess with time. From relativistic time dilation and wormholes to the tangled timelines of Dragon Ball Z.',
+    'colombia-earthquake-2026':
+      'A magnitude 7.4 earthquake hit western Colombia on August 10, 2026. Among the cities affected, Pereira, my city, was one of the hardest hit. What happened, why the buildings that fell fell, and how developers answered with solutions in a matter of hours.',
   },
 
   // Date formatting

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -1100,6 +1100,7 @@ Actualmente estoy enfocado en aplicaciones de IA, productividad para developers 
     'slides-as-code': 'Slides as Code',
     'the-mythos-saga': 'La saga de Mythos',
     'playing-with-time': 'Jugando con el Tiempo',
+    'colombia-earthquake-2026': 'Cuando tembló en Colombia',
   },
   seriesDescriptions: {
     'building-xergioalex':
@@ -1124,6 +1125,8 @@ Actualmente estoy enfocado en aplicaciones de IA, productividad para developers 
       "Los modelos de clase Mythos de Anthropic: de 'demasiado peligroso para liberar' a disponible para todos — y lo que esa capacidad significa para nosotros.",
     'playing-with-time':
       'Ciencia, paradojas y ficción — qué pasa de verdad cuando te metes con el tiempo. Desde la dilatación temporal y los agujeros de gusano hasta las enredadas líneas temporales de Dragon Ball Z.',
+    'colombia-earthquake-2026':
+      'El 10 de agosto de 2026 un terremoto de magnitud 7,4 golpeó el occidente de Colombia. Entre las ciudades afectadas, Pereira, mi ciudad, fue una de las más golpeadas. Qué pasó, por qué se cayó lo que se cayó, y cómo los desarrolladores respondieron con soluciones en cuestión de horas.',
   },
 
   // Date formatting


### PR DESCRIPTION
## Summary

Adds the six-part bilingual series **"When Colombia Shook" / "Cuando tembló en Colombia"** about the August 10, 2026 magnitude 7.4 earthquake in western Colombia and the civic-tech response that followed.

**Every post ships with `draft: true`** — nothing is publicly visible from this PR. It lands the content so it can be reviewed and iterated on before publishing.

## What's included

| Order | Slug | Date |
|---|---|---|
| 1 | `the-day-pereira-went-quiet` | 2026-08-17 |
| 2 | `one-hundred-three-kilometers-down` | 2026-08-20 |
| 3 | `why-twenty-apps-appeared-in-one-week` | 2026-08-24 |
| 4 | `the-map-of-the-network` | 2026-08-27 |
| 5 | `building-software-in-an-emergency` | 2026-08-31 |
| 6 | `what-comes-next-after-the-earthquake` | 2026-09-03 |

- 12 post files (EN + ES parity, same English slugs, matching `pubDate` and filename prefixes)
- Series definition: `src/content/series/colombia-earthquake-2026.md` (`order: 11`)
- Two new secondary tags: `civic-tech` (parent `tech`), `colombia` (parent `personal`)
- Series title/description strings added to `src/lib/translations/{en,es}.ts`

## Checks

- [x] `pnpm run test` — 259 passed
- [x] `pnpm run biome:check` — clean
- [x] `pnpm run astro:check` — 0 errors / 0 warnings / 0 hints
- [x] `pnpm run build` — 418 pages built
- [x] EN/ES parity, same author slug, same series slug
- [x] Spanish diacritics verified
- [x] No placeholder content
- [x] Post descriptions within 130–160 chars

## Known follow-ups (before un-drafting)

- No `heroImage` on any post yet — needs `public/images/blog/posts/{slug}/hero.webp` and a `heroLayout` per post
- Run `/audit-series` for the full pre-publication pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)